### PR TITLE
Updated dockerfile to install vvo and sample_app from individual repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,25 @@ RUN cd ${TEMP_DIR} \
 #       mount other items specifically in the /gridappsd/appplication
 #       and/or /gridappsd/services location in order for gridappsd
 #       to be able to "see" and ultimately start them.
-COPY ./applications /gridappsd/applications
+# comment this out until the applications are removed from GOSS-GridAPPS-D repo
+#COPY ./applications /gridappsd/applications
 COPY ./services /gridappsd/services
 COPY ./gov.pnnl.goss.gridappsd/conf /gridappsd/conf
 COPY ./entrypoint.sh /gridappsd/entrypoint.sh
 COPY ./requirements.txt /gridappsd/requirements.txt
 RUN chmod +x /gridappsd/entrypoint.sh
+
+# Add the gridlabd-vvo app & sample app
+RUN cd ${TEMP_DIR} \
+  && [ ! -d /gridappsd/applications ] && mkdir /gridappsd/applications \
+  && git clone https://github.com/GRIDAPPSD/gridappsd-sample-app -b master \
+  && cp -rp gridappsd-sample-app/sample_app/sample_app /gridappsd/applications \
+  && cp -p  gridappsd-sample-app/sample_app/sample_app.config /gridappsd/applications \
+  && git clone https://github.com/GRIDAPPSD/gridappsd-gridlabd-vvo -b master \
+  && cp -rp gridappsd-gridlabd-vvo/vvo/vvo /gridappsd/applications \
+  && cp -p  gridappsd-gridlabd-vvo/vvo/vvo.config /gridappsd/applications \
+  && rm -r gridappsd-sample-app \
+  && rm -r gridappsd-gridlabd-vvo
 
 COPY ./run-gridappsd.sh /gridappsd/run-gridappsd.sh
 RUN chmod +x /gridappsd/run-gridappsd.sh


### PR DESCRIPTION
# Description

Updated the dockerfile to install vvo and sample_app from individual repos instead of the GOSS-GridAPPS-D repo.

Fixes # (issue)
#593 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Tested the sample_app with the platform.  VVO is not currently registered in the viz so it has not been tested.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/622?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/622'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>