### PR TITLE
Updated gridlabd executable to call the gridlabd.sh bash script which…

### DIFF
--- a/services/GridLAB-D.config
+++ b/services/GridLAB-D.config
@@ -5,7 +5,7 @@
 	"inputs": [],
 	"outputs": [],
 	"static_args": [],
-	"execution_path": "gridlabd",
+	"execution_path": "gridlabd.sh",
 	"type": "EXE",
 	"launch_on_startup": "false",
 	"prereqs": ["fncsgossbridge"],


### PR DESCRIPTION
… sets the required environment variables

# Description

Updated gridlabd executable to call the gridlabd.sh bash script to set the required environment variables for gridlabd.  

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/680?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/680'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>