### PR TITLE
Update travis builds, applications dir, gridappsd user setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,19 +19,4 @@ before_install:
 script:
   # - './gradlew check'
   - './gradlew export'
-  - './.travis/build-docker.sh -b'
-
-# only execute the following instructions in
-# the case of a success (failing at this point
-# won't mark the build as a failure).
-# To have `DOCKER_USERNAME` and `DOCKER_PASSWORD`
-# filled you need to either use `travis`' cli 
-# and then `travis set ..` or go to the travis
-# page of your repository and then change the 
-# environment in the settings pannel.
-after_success:
-  - if [ -n "$DOCKER_USERNAME" -a -n "$DOCKER_PASSWORD" ]; then
-      docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD ;
-      ./.travis/build-docker.sh -p ;
-    fi
-
+  - './.travis/build-docker.sh'

--- a/.travis/build-docker.sh
+++ b/.travis/build-docker.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-usage () {
-  /bin/echo "Usage:  $0 -b Build the docker image"
-  /bin/echo "           -p Push image to dockerhub"
-  exit 2
-}
-
 TAG="$TRAVIS_BRANCH"
 
 ORG=`echo $DOCKER_PROJECT | tr '[:upper:]' '[:lower:]'`
@@ -17,26 +11,60 @@ GITHASH=`git log -1 --pretty=format:"%h"`
 BUILD_VERSION="${TIMESTAMP}_${GITHASH}${TRAVIS_BRANCH:+:$TRAVIS_BRANCH}"
 echo "BUILD_VERSION $BUILD_VERSION"
 
-# parse options
-while getopts bp option ; do
-  case $option in
-    b) # Pass gridappsd tag to docker-compose
-      # Docker file on travis relative from root.
-      docker build --build-arg TIMESTAMP="${BUILD_VERSION}" -t ${IMAGE}:${TIMESTAMP}_${GITHASH} .
-      ;;
-    p) # Pass gridappsd tag to docker-compose
-      if [ -n "$TAG" -a -n "$ORG" ]; then
-        echo "docker push ${IMAGE}:${TIMESTAMP}_${GITHASH}"
-        docker push ${IMAGE}:${TIMESTAMP}_${GITHASH}
-        docker tag ${IMAGE}:${TIMESTAMP}_${GITHASH} ${IMAGE}:$TAG
-        echo "docker push ${IMAGE}:$TAG"
-        docker push ${IMAGE}:$TAG
-      fi
-      ;;
-    *) # Print Usage
-      usage
-      ;;
-  esac
-done
-shift `expr $OPTIND - 1`
+# Pass gridappsd tag to docker-compose
+docker build --build-arg TIMESTAMP="${BUILD_VERSION}" -t ${IMAGE}:${TIMESTAMP}_${GITHASH} .
+status=$?
+if [ $status -ne 0 ]; then
+  echo "Error: status $status"
+  exit 1
+fi
 
+# To have `DOCKER_USERNAME` and `DOCKER_PASSWORD`
+# filled you need to either use `travis`' cli
+# (https://github.com/travis-ci/travis.rb)
+# and then `travis set ..` or go to the travis
+# page of your repository and then change the
+# environment in the settings pannel.
+
+if [ -n "$DOCKER_USERNAME" -a -n "$DOCKER_PASSWORD" ]; then
+
+  echo " "
+  echo "Connecting to docker"
+
+  echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
+  status=$?
+  if [ $status -ne 0 ]; then
+    echo "Error: status $status"
+    exit 1
+  fi
+
+  if [ -n "$TAG" -a -n "$ORG" ]; then
+    # Get the built container name, for builds that cross the hour boundary
+    CONTAINER=`docker images --format "{{.Repository}}:{{.Tag}}" ${IMAGE}`
+
+    echo "docker push ${CONTAINER}"
+    docker push "${CONTAINER}"
+    status=$?
+    if [ $status -ne 0 ]; then
+      echo "Error: status $status"
+      exit 1
+    fi
+
+    echo "docker tag ${CONTAINER} ${IMAGE}:$TAG"
+    docker tag ${CONTAINER} ${IMAGE}:$TAG
+    status=$?
+    if [ $status -ne 0 ]; then
+      echo "Error: status $status"
+      exit 1
+    fi
+
+    echo "docker push ${IMAGE}:$TAG"
+    docker push ${IMAGE}:$TAG
+    status=$?
+    if [ $status -ne 0 ]; then
+      echo "Error: status $status"
+      exit 1
+    fi
+  fi
+
+fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY ./entrypoint.sh /gridappsd/entrypoint.sh
 COPY ./requirements.txt /gridappsd/requirements.txt
 RUN chmod +x /gridappsd/entrypoint.sh
 
-# Add the applications directory
+# Add the applications directory which is necessary for gridappsd to operate.
 RUN if [ ! -d /gridappsd/applications ] ; then  mkdir /gridappsd/applications ; fi 
 
 COPY ./run-gridappsd.sh /gridappsd/run-gridappsd.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,14 @@ RUN cd ${TEMP_DIR} \
 #       mount other items specifically in the /gridappsd/appplication
 #       and/or /gridappsd/services location in order for gridappsd
 #       to be able to "see" and ultimately start them.
-COPY ./applications /gridappsd/applications
 COPY ./services /gridappsd/services
 COPY ./gov.pnnl.goss.gridappsd/conf /gridappsd/conf
 COPY ./entrypoint.sh /gridappsd/entrypoint.sh
 COPY ./requirements.txt /gridappsd/requirements.txt
 RUN chmod +x /gridappsd/entrypoint.sh
+
+# Add the applications directory
+RUN if [ ! -d /gridappsd/applications ] ; then  mkdir /gridappsd/applications ; fi 
 
 COPY ./run-gridappsd.sh /gridappsd/run-gridappsd.sh
 RUN chmod +x /gridappsd/run-gridappsd.sh
@@ -35,8 +37,6 @@ COPY ./opendss/liblinenoise.so /usr/local/lib
 RUN chmod +x /usr/local/bin/opendsscmd && \
   ldconfig
 
-# Add mysql configuration 
-RUN echo "[client]\nuser=gridappsd\npassword=gridappsd1234\ndatabase=gridappsd\nhost=mysql" > /root/.my.cnf
 
 # This is the location that is built using the ./gradlew export command from
 # the command line.  When building this image we must make sure to have run that
@@ -54,11 +54,15 @@ EXPOSE 61616 61613 61614 8000-9000
 WORKDIR /gridappsd
 
 RUN echo $TIMESTAMP > /gridappsd/dockerbuildversion.txt
-RUN useradd -m gridappsd
-#RUN mkdir /etc/sudoers.d  \
-#        && echo "gridappsd    ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/gridappsd
-RUN mkdir /gridappsd/log \
-        && chown gridappsd:gridappsd /gridappsd/log
+
+# Add gridappsd user , sudoers, mysql configuration, log directory
+RUN useradd -m gridappsd \
+    && if [ -d /etc/sudoers.d ] ; then echo "gridappsd    ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/gridappsd ; fi \
+    && echo "[client]\nuser=gridappsd\npassword=gridappsd1234\ndatabase=gridappsd\nhost=mysql" > /home/gridappsd/.my.cnf \
+    && chown gridappsd:gridappsd /home/gridappsd/.my.cnf \
+    && mkdir /gridappsd/log \
+    && chown gridappsd:gridappsd /gridappsd/log
+
 USER gridappsd
 
 ENTRYPOINT ["/gridappsd/entrypoint.sh"]


### PR DESCRIPTION
# Description

Sample app is no longer available in the container, it will be run from a separate container.

Updated travis builds to fail if docker push fails.
Updated travis builds to work across the hour boundary.
Updated gridappsd user setup to add mysql configuration.

Fixes # (issue)

#678 

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
    - applications are not installed

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested through travis builds
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/683%23discussion_r215995509%22%2C%20%22https%3A//github.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/683%23discussion_r215995983%22%2C%20%22https%3A//github.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/683%23discussion_r216003739%22%2C%20%22https%3A//github.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/683%23discussion_r216004143%22%2C%20%22https%3A//github.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/683%23discussion_r216004478%22%2C%20%22https%3A//github.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/683%23discussion_r216461193%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20a4366c968af8f165fcdb0dcbaf6e2edba824468d%20.travis/build-docker.sh%2066%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/683%23discussion_r215995509%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20do%20we%20need%20the%20%5C%22for%20builds%20that%20cross%20the%20hour%20boundary%5C%22%20isn%27t%20this%20just%20going%20to%20be%20the%20built%20container%3F%22%2C%20%22created_at%22%3A%20%222018-09-07T15%3A21%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/3979063%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craig8%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20previous%20logic%20used%20the%20TIMESTAMP%20to%20determine%20the%20container%20name%20for%20the%20docker%20push.%20%20If%20the%20build%20crossed%20the%20top%20of%20the%20our%20the%20TIMESTAMP%20would%20be%20incorrect%20and%20the%20container%20would%20fail%20to%20push%20to%20docker%20hub.%20%20With%20the%20new%20method%2C%20we%20lookup%20the%20built%20container%20name%20for%20the%20docker%20push.%22%2C%20%22created_at%22%3A%20%222018-09-07T15%3A45%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/15236222%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tonya1%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes...the%20thing%20is%20it%20doesn%27t%20matter%20now%20if%20it%20crosses%20the%20boundary%20either%20way%20it%20will%20look%20it%20up%20correct%3F%22%2C%20%22created_at%22%3A%20%222018-09-07T15%3A48%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/3979063%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craig8%22%7D%7D%2C%20%7B%22body%22%3A%20%22Now%20that%20the%20build%20and%20push%20are%20in%20one%20step%20it%20is%20really%20no%20longer%20an%20issue%20since%20the%20TIMESTAMP%20is%20only%20defined%20once.%20%20The%20%5Cr%5CnCONTAINER%3D%60docker%20images%20--format%20%5C%22%7B%7B.Repository%7D%7D%3A%7B%7B.Tag%7D%7D%5C%22%20%24%7BIMAGE%7D%60%5Cr%5Cnline%20will%20make%20sure%20it%20tries%20to%20push%20the%20container%20that%20was%20created.%22%2C%20%22created_at%22%3A%20%222018-09-10T20%3A28%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/15236222%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tonya1%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20.travis/build-docker.sh%3AL11-71%22%7D%2C%20%22Pull%20a4366c968af8f165fcdb0dcbaf6e2edba824468d%20Dockerfile%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/683%23discussion_r215995983%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Add%20in%20the%20comment%20that%20this%20is%20necessary%20for%20gridappsd%20to%20operate.%22%2C%20%22created_at%22%3A%20%222018-09-07T15%3A22%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/3979063%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/craig8%22%7D%7D%2C%20%7B%22body%22%3A%20%22added%20additional%20comment.%22%2C%20%22created_at%22%3A%20%222018-09-07T15%3A47%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/15236222%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tonya1%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20Dockerfile%3AL18-33%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull a4366c968af8f165fcdb0dcbaf6e2edba824468d .travis/build-docker.sh 66'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/683#discussion_r215995509'>File: .travis/build-docker.sh:L11-71</a></b>
- <a href='https://github.com/craig8'><img border=0 src='https://avatars3.githubusercontent.com/u/3979063?v=4' height=16 width=16></a> why do we need the "for builds that cross the hour boundary" isn't this just going to be the built container?
- <a href='https://github.com/tonya1'><img border=0 src='https://avatars0.githubusercontent.com/u/15236222?v=4' height=16 width=16></a> The previous logic used the TIMESTAMP to determine the container name for the docker push.  If the build crossed the top of the our the TIMESTAMP would be incorrect and the container would fail to push to docker hub.  With the new method, we lookup the built container name for the docker push.
- <a href='https://github.com/craig8'><img border=0 src='https://avatars3.githubusercontent.com/u/3979063?v=4' height=16 width=16></a> Yes...the thing is it doesn't matter now if it crosses the boundary either way it will look it up correct?
- <a href='https://github.com/tonya1'><img border=0 src='https://avatars0.githubusercontent.com/u/15236222?v=4' height=16 width=16></a> Now that the build and push are in one step it is really no longer an issue since the TIMESTAMP is only defined once.  The
CONTAINER=`docker images --format "{{.Repository}}:{{.Tag}}" ${IMAGE}`
line will make sure it tries to push the container that was created.
- [ ] <a href='#crh-comment-Pull a4366c968af8f165fcdb0dcbaf6e2edba824468d Dockerfile 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/683#discussion_r215995983'>File: Dockerfile:L18-33</a></b>
- <a href='https://github.com/craig8'><img border=0 src='https://avatars3.githubusercontent.com/u/3979063?v=4' height=16 width=16></a> Add in the comment that this is necessary for gridappsd to operate.
- <a href='https://github.com/tonya1'><img border=0 src='https://avatars0.githubusercontent.com/u/15236222?v=4' height=16 width=16></a> added additional comment.


<a href='https://www.codereviewhub.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/683?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/683?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/683'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>