### PR TITLE
updated measurement name and for simulation data query

### DIFF
--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesData.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesData.java
@@ -13,7 +13,7 @@ public class RequestTimeseriesData implements Serializable {
 	private static final long serialVersionUID = -820277813503252519L;
 	
 	public enum RequestType {
-	    weather, simulation
+	    weather, PROVEN_MEASUREMENT
 	}
 	
 	RequestType queryMeasurement;
@@ -54,8 +54,9 @@ public class RequestTimeseriesData implements Serializable {
 	public static RequestTimeseriesData parse(String jsonString){
 		Gson  gson = new Gson();
 		RequestTimeseriesData obj = gson.fromJson(jsonString, RequestTimeseriesData.class);
-		if(obj.queryMeasurement==RequestType.simulation && !obj.queryFilter.containsKey("simulationId"))
-				throw new JsonSyntaxException("Expected attribute simulationId not found");
+		if(obj.queryMeasurement==RequestType.PROVEN_MEASUREMENT)
+			if(obj.queryFilter==null || !obj.queryFilter.containsKey("hasSimulationId"))
+				throw new JsonSyntaxException("Expected filter hasSimulationId not found.");
 		return obj;
 	}
 	

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessEvent.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessEvent.java
@@ -278,6 +278,7 @@ public class ProcessEvent implements GossResponseEvent {
 			PrintWriter pw = new PrintWriter(sw);
 			e.printStackTrace(pw);
 			this.error(processId,sw.toString());
+			sendError(client, event.getReplyDestination(), sw.toString(), processId);
 		}
 	}
 


### PR DESCRIPTION
- Changed query type enum to weather and PROVEN_MEASURMENT instead of weather and simulation.
- Edited filter check for hasSimulationId instead of simulationId
- Added code to return error response back to resquester in case of exception.