### PR TITLE
(bugfix/815) status messages from the bridge were being published

### DIFF
--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -741,7 +741,7 @@ def _send_simulation_status(status, message, log_level):
         status_message = {
             "source" : os.path.basename(__file__),
             "processId" : str(simulation_id),
-            "timestamp" : int(time.mktime(t_now.timetuple())),
+            "timestamp" : int(time.mktime(t_now.timetuple()))*1000,
             "processStatus" : status,
             "logMessage" : str(message),
             "logLevel" : log_level,


### PR DESCRIPTION
# status messages coming from the fncs_goss_bridge were being published with timestamps in seconds.
rather than milliseconds. This PR corrects that.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I ran a simulation then queried the mysql database and confirmed that status messages from the bridge had the correct date.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/827?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/GRIDAPPSD/GOSS-GridAPPS-D/pull/827'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>