### PR TITLE
Bugfix/831

### DIFF
--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
@@ -379,7 +379,11 @@ public class GLDSimulationOutputConfigurationHandler extends BaseConfigurationHa
 		} else if (conductingEquipmentType.contains("PowerElectronicsConnection")) {
 			if(measurementType.equals("VA")) {
 				objectName = conductingEquipmentName;
-				propertyName = "measured_power_" + phases;
+				if(phases.equals("1") || phases.equals("2")) {
+					propertyName = "indiv_measured_power_" + phases;
+				} else {
+					propertyName = "measured_power_" + phases;
+				}
 			} else if (measurementType.equals("PNV")) {
 				objectName = conductingEquipmentName;
 				propertyName = "voltage_" + phases;
@@ -394,7 +398,10 @@ public class GLDSimulationOutputConfigurationHandler extends BaseConfigurationHa
 
 		}
 		if(measurements.containsKey(objectName)) {
-			measurements.get(objectName).add(new JsonPrimitive(propertyName));
+			JsonPrimitive p = new JsonPrimitive(propertyName);
+			if(!measurements.get(objectName).contains(p)) {
+				measurements.get(objectName).add(new JsonPrimitive(propertyName));
+			}
 		} else {
 			JsonArray newMeasurements = new JsonArray();
 			newMeasurements.add(new JsonPrimitive(propertyName));

--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -909,7 +909,10 @@ def _create_cim_object_map(map_file=None):
                     elif "PowerElectronicsConnection" in conducting_equipment_type:
                         if measurement_type == "VA":
                             object_name = conducting_equipment_name;
-                            property_name = "measured_power_" + phases;
+                            if phases in ["1","2"]:
+                                property_name = "indiv_measured_power_" + phases;
+                            else:
+                                property_name = "measured_power_" + phases;
                         elif measurement_type == "PNV":
                             object_name = conducting_equipment_name;
                             property_name = "voltage_" + phases;

--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -575,61 +575,62 @@ def _get_fncs_bus_messages(simulation_id):
                         err_msg = "All measurements for object {} are missing from the simulator output.".format(x)
                         _send_simulation_status('RUNNING', err_msg, 'WARN')
                         #raise RuntimeError(err_msg)
-                    for y in object_property_to_measurement_id.get(x,{}):
-                        measurement = {}
-                        property_name = y["property"]
-                        measurement["measurement_mrid"] = y["measurement_mrid"]
-                        phases = y["phases"]
-                        conducting_equipment_type_str = y["conducting_equipment_type"]
-                        prop_val_str = gld_properties_dict.get(property_name, None)
-                        if prop_val_str == None:
-                            err_msg = "{} measurement for object {} is missing from the simulator output.".format(property_name, x)
-                            _send_simulation_status('RUNNING', err_msg, 'WARN')
-                            #raise RuntimeError("{} measurement for object {} is missing from the simulator output.".format(property_name, x))
-                        else:
-                            val_str = str(prop_val_str).split(" ")[0]
-                            conducting_equipment_type = str(conducting_equipment_type_str).split("_")[0]
-                            if conducting_equipment_type == "LinearShuntCompensator":
-                                if property_name in ["shunt_"+phases,"voltage_"+phases]:
-                                    val = complex(val_str)
-                                    (mag,ang_rad) = cmath.polar(val)
-                                    ang_deg = math.degrees(ang_rad)
-                                    measurement["magnitude"] = mag
-                                    measurement["angle"] = ang_deg
-                                else:
-                                    if val_str == "OPEN":
-                                        measurement["value"] = 0
-                                    else:
-                                        measurement["value"] = 1
-                            elif conducting_equipment_type == "PowerTransformer":
-                                if property_name in ["power_in_"+phases,"voltage_"+phases,"current_in_"+phases]:
-                                    val = complex(val_str)
-                                    (mag,ang_rad) = cmath.polar(val)
-                                    ang_deg = math.degrees(ang_rad)
-                                    measurement["magnitude"] = mag
-                                    measurement["angle"] = ang_deg
-                                else:
-                                    measurement["value"] = int(val_str)
-                            elif conducting_equipment_type in ["ACLineSegment","LoadBreakSwitch","EnergyConsumer","PowerElectronicsConnection"]:
-                                val = complex(val_str)
-                                (mag,ang_rad) = cmath.polar(val)
-                                ang_deg = math.degrees(ang_rad)
-                                measurement["magnitude"] = mag
-                                measurement["angle"] = ang_deg
-                            elif conducting_equipment_type == "RatioTapChanger":
-                                if property_name in ["power_in_"+phases,"voltage_"+phases,"current_in_"+phases]:
-                                    val = complex(val_str)
-                                    (mag,ang_rad) = cmath.polar(val)
-                                    ang_deg = math.degrees(ang_rad)
-                                    measurement["magnitude"] = mag
-                                    measurement["angle"] = ang_deg
-                                else:
-                                    measurement["value"] = int(val_str)
+                    else:
+                        for y in object_property_to_measurement_id.get(x,{}):
+                            measurement = {}
+                            property_name = y["property"]
+                            measurement["measurement_mrid"] = y["measurement_mrid"]
+                            phases = y["phases"]
+                            conducting_equipment_type_str = y["conducting_equipment_type"]
+                            prop_val_str = gld_properties_dict.get(property_name, None)
+                            if prop_val_str == None:
+                                err_msg = "{} measurement for object {} is missing from the simulator output.".format(property_name, x)
+                                _send_simulation_status('RUNNING', err_msg, 'WARN')
+                                #raise RuntimeError("{} measurement for object {} is missing from the simulator output.".format(property_name, x))
                             else:
-                                _send_simulation_status('RUNNING', conducting_equipment_type+" not recognized", 'WARN')
-                                raise RuntimeError("{} is not a recognized conducting equipment type.".format(conducting_equipment_type))
-                                # Should it raise runtime?
-                            cim_measurements_dict["message"]["measurements"].append(measurement)
+                                val_str = str(prop_val_str).split(" ")[0]
+                                conducting_equipment_type = str(conducting_equipment_type_str).split("_")[0]
+                                if conducting_equipment_type == "LinearShuntCompensator":
+                                    if property_name in ["shunt_"+phases,"voltage_"+phases]:
+                                        val = complex(val_str)
+                                        (mag,ang_rad) = cmath.polar(val)
+                                        ang_deg = math.degrees(ang_rad)
+                                        measurement["magnitude"] = mag
+                                        measurement["angle"] = ang_deg
+                                    else:
+                                        if val_str == "OPEN":
+                                            measurement["value"] = 0
+                                        else:
+                                            measurement["value"] = 1
+                                elif conducting_equipment_type == "PowerTransformer":
+                                    if property_name in ["power_in_"+phases,"voltage_"+phases,"current_in_"+phases]:
+                                        val = complex(val_str)
+                                        (mag,ang_rad) = cmath.polar(val)
+                                        ang_deg = math.degrees(ang_rad)
+                                        measurement["magnitude"] = mag
+                                        measurement["angle"] = ang_deg
+                                    else:
+                                        measurement["value"] = int(val_str)
+                                elif conducting_equipment_type in ["ACLineSegment","LoadBreakSwitch","EnergyConsumer","PowerElectronicsConnection"]:
+                                    val = complex(val_str)
+                                    (mag,ang_rad) = cmath.polar(val)
+                                    ang_deg = math.degrees(ang_rad)
+                                    measurement["magnitude"] = mag
+                                    measurement["angle"] = ang_deg
+                                elif conducting_equipment_type == "RatioTapChanger":
+                                    if property_name in ["power_in_"+phases,"voltage_"+phases,"current_in_"+phases]:
+                                        val = complex(val_str)
+                                        (mag,ang_rad) = cmath.polar(val)
+                                        ang_deg = math.degrees(ang_rad)
+                                        measurement["magnitude"] = mag
+                                        measurement["angle"] = ang_deg
+                                    else:
+                                        measurement["value"] = int(val_str)
+                                else:
+                                    _send_simulation_status('RUNNING', conducting_equipment_type+" not recognized", 'WARN')
+                                    raise RuntimeError("{} is not a recognized conducting equipment type.".format(conducting_equipment_type))
+                                    # Should it raise runtime?
+                                cim_measurements_dict["message"]["measurements"].append(measurement)
                 cim_output = cim_measurements_dict
             else:
                 err_msg = "The message recieved from the simulator did not have the simulation id as a key in the json message."


### PR DESCRIPTION
# Description

This PR fixes an python exception that occurs in the FNCS_GOSS_Bridge.py. It stops the bridge from trying to grab missing measurements after its has been determined that the measurements are missing. It also corrected an error for the measured power property names of triplex meters when those measurements are present. It also prevents duplicate property list entries in the model_output.json file that GridLAB-D when there are multiple CIM measurements that point to the same object and property pair in GridLAB-D. Note the bridge will still output these measurements on the CIM side it just prevents GridLAB-D from publishing the same object/property value more than once in a timestep.

Fixes #831

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I successfully ran all 4 feeder models.
