### PR TITLE
(develop) Fixing typo. "regulator" was "regu:lator".

### DIFF
--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -951,7 +951,7 @@ def _create_cim_object_map(map_file=None):
                             "name" : object_name,
                             "phases" : object_phases[z],
                             "total_phases" : "".join(object_phases),
-                            "type" : "regu:lator"
+                            "type" : "regulator"
                         }
                 for y in switches:
                     object_mrid_to_name[y.get("mRID")] = {


### PR DESCRIPTION
# Description

There was a typo where "regulator" was spelled "regu:lator". This caused python error when trying to send commands to regulator objects in the bridge.
