### PR TITLE
Removed gridappsd-python from the gridappsd container for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,6 @@ FROM gridappsd/gridappsd_base${GRIDAPPSD_BASE_VERSION}
 
 ARG TIMESTAMP
 
-# Get the gridappsd-python from the proper repository
-RUN cd ${TEMP_DIR} \
-  && git clone https://github.com/GRIDAPPSD/gridappsd-python -b develop \
-  && cd gridappsd-python \
-  && pip3 install . \
-  && pip install . \
-  && rm -rf /root/.cache/pip/wheels
-
 # Copy initial applications and services into the container.
 # 
 # NOTE: developers should mount a volume over the top of these or


### PR DESCRIPTION
# Description

Removes gridappsd-python from the main container.  This will get added back when we have python 3.6 support in the main container and have upgraded fncsgossbridge to utilize it.