### PR TITLE
Fix gridappsd python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,24 @@ FROM gridappsd/gridappsd_base${GRIDAPPSD_BASE_VERSION}
 
 ARG TIMESTAMP
 
+# Update to use python 3.6 as default for python3.
+RUN sudo apt-get update && sudo apt-get install -y software-properties-common \ 
+  && sudo add-apt-repository ppa:deadsnakes/ppa \
+  && sudo apt-get update && sudo apt-get install -y python3.6 python3.6-dev \
+  && sudo /usr/bin/update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 \
+  && sudo /usr/bin/update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1 \
+  && sudo sudo /usr/bin/update-alternatives  --set python /usr/bin/python3.6 \
+  && sudo sudo /usr/bin/update-alternatives  --set python3 /usr/bin/python3.6 \
+  && rm -rf /var/cache/apt/archives/* \
+  && rm -rf /root/.cache/pip/wheels
+
+# Get the gridappsd-python from the proper repository
+RUN cd ${TEMP_DIR} \
+  && git clone https://github.com/GRIDAPPSD/gridappsd-python -b develop \
+  && cd gridappsd-python \
+  && pip3 install . \
+  && rm -rf /root/.cache/pip/wheels
+
 # Copy initial applications and services into the container.
 # 
 # NOTE: developers should mount a volume over the top of these or


### PR DESCRIPTION
This PR puts back in python3.6 into the container so that gridappsd-python can be available for services that require it (e.g. DNP3 service)