### PR TITLE
Changed the built branch to 'develop' so that it doesn't use latest

### DIFF
--- a/build-gridappsd-container
+++ b/build-gridappsd-container
@@ -2,4 +2,4 @@
 rm -rf gov.pnnl.goss/gridappsd/generated
 ./gradlew export
 
-docker build --no-cache --network=host -t gridappsd .
+docker build --no-cache --network=host -t gridappsd:develop .


### PR DESCRIPTION
# Description

When running the create docker script it creates the image as :develop instead of latest