### PR TITLE
Issue 947 Fix

### DIFF
--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
@@ -310,12 +310,6 @@ public class GLDSimulationOutputConfigurationHandler extends BaseConfigurationHa
 			} else if (measurementType.equals("Pos")) {
 				objectName = conductingEquipmentName;
 				propertyName = "tap_" + phases;
-			} else if (measurementType.equals("PNV")) {
-				objectName = connectivityNode;
-				propertyName = "voltage_"+phases;
-			} else if (measurementType.equals("A")) {
-				objectName = conductingEquipmentName;
-				propertyName = "current_out_" + phases;
 			} else {
 				throw new JsonParseException(String.format("CimMeasurementsToGldPubs::parseMeasurement: The value of measurementType is not a valid type.\nValid types for RatioTapChanger are VA, PNV, A, and Pos.\nmeasurementType = %s.",measurementType));
 			}

--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -366,7 +366,7 @@ class GOSSListener(object):
         prefix = ""
         stored_object = object_mrid_to_name.get(object_mrid)
         if stored_object == None:
-            cim_object_dict = goss_connection.query_object(object_mrid, model_mrid)
+            cim_object_dict = goss_connection.query_object_dictionary(model_id=model_mrid, obejct_id=object_mrid)
             object_base_name = cim_object_dict.get["name",""]
             object_type = cim_object_dict.get["type",""]
             if object_type == "LinearShuntCompensator":
@@ -964,7 +964,7 @@ def _create_cim_object_map(map_file=None):
             object_property_to_measurement_id = {}
             object_mrid_to_name = {}
             for x in feeders:
-                model_mrid = x.get["mrid",""]
+                model_mrid = x.get("mrid","")
                 measurements = x.get("measurements",[])
                 capacitors = x.get("capacitors",[])
                 regulators = x.get("regulators",[])

--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -145,11 +145,11 @@ difference_attribute_map = {
     },
     "PowerElectronicsConnection.q": {
         "pv": {
-            "property": ["P_Out"],
+            "property": ["Q_Out"],
             "prefix": "inv_pv_"
         },
         "battery": {
-            "property": ["P_Out"],
+            "property": ["Q_Out"],
             "prefix": "inv_bat_"
         }
     },


### PR DESCRIPTION
Providing fix for issue 947, changing the bridge to use the gridappsd-python api,

removing redundant code in the GLDSimulationOutputConfigurationHandler.java. 

I've also added the fault implementation inside of the Bridge. More pieces need to be done to test this functionality.

1.) The startup.glm file will need two additional objects present in it. A fault_check object and an eventgen object. I will create a separate issue with more details for this over the weekend.

2.) the query object dictionary by type query needs to be able to work if we know the object mrid but not the object type.

3.) The query object dictionary by type function needs to be added to the gridappsd-python api.

4.) gridlabd branch feature/1162 needs to be used in the container. This branch will be merged into develop once testing has been completed.
