### PR TITLE
fixing VSOURCE query

### DIFF
--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDAllConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDAllConfigurationHandler.java
@@ -344,7 +344,7 @@ public class GLDAllConfigurationHandler extends BaseConfigurationHandler impleme
 					+ "?s c:ConnectivityNode.ConnectivityNodeContainer|c:Equipment.EquipmentContainer ?fdr."
 					+ "?s c:ConductingEquipment.BaseVoltage ?lev."
 					+ " ?lev c:BaseVoltage.nominalVoltage ?vnom."
-					+ "} ORDER by ?vnom";
+					+ "} ORDER by DESC(?vnom");
 			ResultSet rs = powergridModelManager.queryResultSet(modelId, nominalVoltageQuery, processId, username);
 			QuerySolution binding = rs.nextSolution();
 			String vnom = ((Literal) binding.get("vnom")).toString();


### PR DESCRIPTION
modifying VSOURCE query to order vnom in descending order to ensurefirst vnom is the nominal voltage of the head of the feeder. This is what is causing IEEE123pv to fail to run.

