### PR TITLE
Fix for 1038

### DIFF
--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
@@ -391,13 +391,13 @@ public class GLDSimulationOutputConfigurationHandler extends BaseConfigurationHa
 		} else if (conductingEquipmentType.contains("SynchronousMachine")) {
 			if(measurementType.equals("VA")) {
 				objectName = conductingEquipmentName;
-				propertyName = "power_out_" + phases;
+				propertyName = "measured_power_" + phases;
 			} else if (measurementType.equals("PNV")) {
 				objectName = connectivityNode;
 				propertyName = "voltage_" + phases;
 			} else if (measurementType.equals("A")) {
 				objectName = conductingEquipmentName;
-				propertyName = "current_out_" + phases;
+				propertyName = "measured_current_" + phases;
 			} else {
 				throw new JsonParseException(String.format("CimMeasurementsToGldPubs::parseMeasurement: The value of measurementType is not a valid type.\nValid types for SynchronousMachine are VA, A, and PNV.\nmeasurementType = %s.",measurementType));
 			}

--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -1101,7 +1101,7 @@ def _create_cim_object_map(map_file=None):
                     elif "SynchronousMachine" in conducting_equipment_type:
                         if measurement_type == "VA":
                             object_name = conducting_equipment_name;
-                            property_name = "power_out_" + phases;
+                            property_name = "measured_power_" + phases;
                         elif measurement_type == "PNV":
                             object_name = connectivity_node;
                             property_name = "voltage_" + phases;


### PR DESCRIPTION
# Description

This fixes issue 1038. There was an incorrect property name assignment for SyncronousMachine VA measurements.

Fixes # 1038

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run the 9500 node test feeder and you should not get any missing measurement warning messages in the viz message log.

