### PR TITLE
fncs_goss_bridge to output dictionary for measurements

### DIFF
--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -44,6 +44,7 @@ Created on Jan 6, 2017
 
 @author: fish334
 @author: poorva1209
+@author: craig8
 """
 import argparse
 import cmath
@@ -71,6 +72,8 @@ except:
     else:
         sys.stdout.write("Running tests.\n")
         fncs = {}
+
+__version__ = '2019.9.0'
 
 input_from_goss_topic = '/topic/goss.gridappsd.fncs.input' #this should match GridAppsDConstants.topic_FNCS_input
 output_to_simulation_manager = 'goss.gridappsd.fncs.output'
@@ -676,7 +679,7 @@ def _publish_to_fncs_bus(simulation_id, goss_message, command_filter):
 
 
 def _get_fncs_bus_messages(simulation_id, measurement_filter):
-    """publish a message received from the GOSS bus to the FNCS bus.
+    """ retrieve the measurment dictionary from the FNCS message bus
 
     Function arguments:
         simulation_id -- Type: string. Description: The simulation id.
@@ -708,7 +711,7 @@ def _get_fncs_bus_messages(simulation_id, measurement_filter):
                 "simulation_id": simulation_id,
                 "message" : {
                     "timestamp" : int(time.mktime(t_now.timetuple())),
-                    "measurements" : []
+                    "measurements" : {}
                 }
             }
 
@@ -795,7 +798,8 @@ def _get_fncs_bus_messages(simulation_id, measurement_filter):
                                         _send_simulation_status('RUNNING', conducting_equipment_type+" not recognized", 'WARN')
                                         raise RuntimeError("{} is not a recognized conducting equipment type.".format(conducting_equipment_type))
                                         # Should it raise runtime?
-                                    cim_measurements_dict["message"]["measurements"].append(measurement)
+                                    # change to be a dictionary rather than an array
+                                    cim_measurements_dict['message']["measurements"][measurement["measurement_mrid"]] = measurement
                 cim_output = cim_measurements_dict
             else:
                 err_msg = "The message recieved from the simulator did not have the simulation id as a key in the json message."


### PR DESCRIPTION
Fixes GRIDAPPSD/GOSS-GRIDAPPS-D#1076 for the 2019-09.0 release.

This should be released with the https://github.com/GRIDAPPSD/gridappsd-python/pull/25 and the sensor service update TBD later tonight

```
//Old Format
{
                "measurements": [{
                                "measurement_mrid": "_00125ca3-12ca-4b8b-a148-c60e03aa7f9f",
                                "magnitude": 78103.82848323896,
                                "angle": -99.22044324389712
                }, {
                                "measurement_mrid": "_0032c3cd-5dec-4944-b1bc-b97b3ec646fc",
                                "magnitude": 2284.5940488360206,
                                "angle": -2.8059748340329578
                }]
}


//New format
{
                "measurements": {
                                "_00125ca3-12ca-4b8b-a148-c60e03aa7f9f": {
                                                "measurement_mrid": "_00125ca3-12ca-4b8b-a148-c60e03aa7f9f",
                                                "magnitude": 78103.82848323896,
                                                "angle": -99.22044324389712
                                },
                                "_0032c3cd-5dec-4944-b1bc-b97b3ec646fc": {
                                                "measurement_mrid": "_0032c3cd-5dec-4944-b1bc-b97b3ec646fc",
                                                "magnitude": 2284.5940488360206,
                                                "angle": -2.8059748340329578
                                }
                }
}
```

Things that need to be coordinated with this schema change

- [x] Viz
- [ ] Proven
- [ ] Apps 