### PR TITLE
Switch POS property map change

### DIFF
--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
@@ -341,7 +341,7 @@ public class GLDSimulationOutputConfigurationHandler extends BaseConfigurationHa
 				propertyName = "voltage_" + phases;
 			} else if (measurementType.equals("Pos")) {
 				objectName = conductingEquipmentName;
-				propertyName = "phase_" + phases + "_state";
+				propertyName = "status";
 			} else if (measurementType.equals("A")) {
 				objectName = conductingEquipmentName;
 				if (phases.equals("1")) {

--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -1082,7 +1082,7 @@ def _create_cim_object_map(map_file=None):
                             property_name = "voltage_" + phases;
                         elif measurement_type == "Pos":
                             object_name = conducting_equipment_name
-                            property_name = "phase_" + phases + "_state"
+                            property_name = "status"
                         elif measurement_type == "A":
                             object_name = conducting_equipment_name;
                             property_name = "current_in_" + phases;

--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -211,7 +211,6 @@ class GOSSListener(object):
         self.command_filter = []
         self.filter_all_commands = False
         self.filter_all_measurements = False
-        self.message_id_list = []
 
     def run_simulation(self,run_realtime):
         try:
@@ -260,14 +259,6 @@ class GOSSListener(object):
     def on_message(self, headers, msg):
         message = {}
         try:
-            headers_dict = yaml.safe_load(str(headers))
-            destination = headers_dict['destination']
-            message_id = headers_dict['message-id']
-            if str(destination).startswith('/temp-queue'):
-                return
-            if str(message_id) in self.message_id_list:
-                return
-            self.message_id_list.append(str(message_id))
             message_str = 'received message '+str(headers)+'________________'+str(msg)
 
             if fncs.is_initialized():


### PR DESCRIPTION
changing the property for Switch POS measurements to the status property in the switch object in gridlabd. This change is necessary due to a change in GridLAB-D switch object. and removed message id checking in the bridge as that is now being done in the gridappsd-python api.
