### PR TITLE
Model state

### DIFF
--- a/gov.pnnl.goss.gridappsd/bnd.bnd
+++ b/gov.pnnl.goss.gridappsd/bnd.bnd
@@ -29,7 +29,7 @@
 	osgi.enroute.base.api,\
 	org.mockito.mockito-all,\
 	httpcore,\
-	blazegraph.cim2glm;version=16.1.0,\
+	blazegraph.cim2glm;version=17.0.0,\
 	httpclient,\
 	com.bigdata.rdf,\
     proven-client;version=0.2.3,\

--- a/gov.pnnl.goss.gridappsd/bnd.bnd
+++ b/gov.pnnl.goss.gridappsd/bnd.bnd
@@ -29,7 +29,7 @@
 	osgi.enroute.base.api,\
 	org.mockito.mockito-all,\
 	httpcore,\
-	blazegraph.cim2glm;version=15.0.0,\
+	blazegraph.cim2glm;version=16.1.0,\
 	httpclient,\
 	com.bigdata.rdf,\
     proven-client;version=0.2.3,\

--- a/gov.pnnl.goss.gridappsd/bnd.bnd
+++ b/gov.pnnl.goss.gridappsd/bnd.bnd
@@ -29,7 +29,7 @@
 	osgi.enroute.base.api,\
 	org.mockito.mockito-all,\
 	httpcore,\
-	blazegraph.cim2glm;version=14.0.0,\
+	blazegraph.cim2glm;version=15.0.0,\
 	httpclient,\
 	com.bigdata.rdf,\
     proven-client;version=0.2.3,\

--- a/gov.pnnl.goss.gridappsd/bnd.bnd
+++ b/gov.pnnl.goss.gridappsd/bnd.bnd
@@ -29,7 +29,7 @@
 	osgi.enroute.base.api,\
 	org.mockito.mockito-all,\
 	httpcore,\
-	blazegraph.cim2glm;version=13.0.0,\
+	blazegraph.cim2glm;version=14.0.0,\
 	httpclient,\
 	com.bigdata.rdf,\
     proven-client;version=0.2.3,\

--- a/gov.pnnl.goss.gridappsd/run.bnd.bndrun
+++ b/gov.pnnl.goss.gridappsd/run.bnd.bndrun
@@ -74,7 +74,7 @@
 	httpcore,\
 	httpclient,\
 	xml-apis,\
-	blazegraph.cim2glm;version=13.0.0,\
+	blazegraph.cim2glm;version=14.0.0,\
 	org.eclipse.jetty.aggregate.jetty-all-server;version=7.6.9,\
 	javax.servlet-api,\
 	com.bigdata.rdf,\

--- a/gov.pnnl.goss.gridappsd/run.bnd.bndrun
+++ b/gov.pnnl.goss.gridappsd/run.bnd.bndrun
@@ -74,7 +74,7 @@
 	httpcore,\
 	httpclient,\
 	xml-apis,\
-	blazegraph.cim2glm;version=16.1.0,\
+	blazegraph.cim2glm;version=17.0.0,\
 	org.eclipse.jetty.aggregate.jetty-all-server;version=7.6.9,\
 	javax.servlet-api,\
 	com.bigdata.rdf,\

--- a/gov.pnnl.goss.gridappsd/run.bnd.bndrun
+++ b/gov.pnnl.goss.gridappsd/run.bnd.bndrun
@@ -74,7 +74,7 @@
 	httpcore,\
 	httpclient,\
 	xml-apis,\
-	blazegraph.cim2glm;version=15.0.0,\
+	blazegraph.cim2glm;version=16.1.0,\
 	org.eclipse.jetty.aggregate.jetty-all-server;version=7.6.9,\
 	javax.servlet-api,\
 	com.bigdata.rdf,\

--- a/gov.pnnl.goss.gridappsd/run.bnd.bndrun
+++ b/gov.pnnl.goss.gridappsd/run.bnd.bndrun
@@ -74,7 +74,7 @@
 	httpcore,\
 	httpclient,\
 	xml-apis,\
-	blazegraph.cim2glm;version=14.0.0,\
+	blazegraph.cim2glm;version=15.0.0,\
 	org.eclipse.jetty.aggregate.jetty-all-server;version=7.6.9,\
 	javax.servlet-api,\
 	com.bigdata.rdf,\

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/BaseConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/BaseConfigurationHandler.java
@@ -64,7 +64,8 @@ public abstract class BaseConfigurationHandler  implements ConfigurationHandler 
 	
 //	private volatile LogManager logManager;
 	
-	
+	public static final String MODELSTATE = "model_state";
+
 	public BaseConfigurationHandler() {
 	}
 	 

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/CIMDictionaryConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/CIMDictionaryConfigurationHandler.java
@@ -51,6 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import gov.pnnl.goss.cim2glm.CIMImporter;
+import gov.pnnl.goss.cim2glm.components.ModelState;
 import gov.pnnl.goss.cim2glm.queryhandler.QueryHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationManager;
@@ -114,12 +115,15 @@ public class CIMDictionaryConfigurationHandler extends BaseConfigurationHandler 
 
 		String simulationId = GridAppsDConstants.getStringProperty(parameters, SIMULATIONID, null);
 		boolean useHouses = false;
-                if(parameters.containsKey(USEHOUSES))
-                        useHouses = GridAppsDConstants.getBooleanProperty(parameters, USEHOUSES, false);
+		if(parameters.containsKey(USEHOUSES))
+			useHouses = GridAppsDConstants.getBooleanProperty(parameters, USEHOUSES, false);
+        ModelState modelState = new ModelState();
 		File configFile = null;
 		if(simulationId!=null){
 			SimulationContext simulationContext = simulationManager.getSimulationContextForId(simulationId);
 			if(simulationContext!=null){
+				modelState = simulationContext.getModelState();
+				
 				configFile = new File(simulationContext.getSimulationDir()+File.separator+GLDAllConfigurationHandler.DICTIONARY_FILENAME);
 				//If the config file already has been created for this simulation then return it
 				if(configFile.exists()){
@@ -133,13 +137,11 @@ public class CIMDictionaryConfigurationHandler extends BaseConfigurationHandler 
 		}
 		
 		
-		
 		String modelId = GridAppsDConstants.getStringProperty(parameters, MODELID, null);
 		if(modelId==null || modelId.trim().length()==0){
 			logError("No "+MODELID+" parameter provided", processId, username, logManager);
 			throw new Exception("Missing parameter "+MODELID);
 		}
-		
 		
 		String bgHost = configManager.getConfigurationProperty(GridAppsDConstants.BLAZEGRAPH_HOST_PATH);
 		if(bgHost==null || bgHost.trim().length()==0){
@@ -153,9 +155,9 @@ public class CIMDictionaryConfigurationHandler extends BaseConfigurationHandler 
 		CIMImporter cimImporter = new CIMImporter(); 
 		//If the simulation info is available also write to file
 		if(configFile!=null){
-			cimImporter.generateDictionaryFile(queryHandler, new PrintWriter(new FileWriter(configFile)),useHouses);
+			cimImporter.generateDictionaryFile(queryHandler, new PrintWriter(new FileWriter(configFile)),useHouses,modelState);
 		} else {
-			cimImporter.generateDictionaryFile(queryHandler, out, useHouses);
+			cimImporter.generateDictionaryFile(queryHandler, out, useHouses,modelState);
 		}
 		if(configFile!=null){
 			//config was written to file, so return that

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/CIMDictionaryConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/CIMDictionaryConfigurationHandler.java
@@ -51,7 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import gov.pnnl.goss.cim2glm.CIMImporter;
-import gov.pnnl.goss.cim2glm.ModelState;
+import gov.pnnl.goss.cim2glm.dto.ModelState;
 import gov.pnnl.goss.cim2glm.queryhandler.QueryHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationManager;

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/CIMDictionaryConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/CIMDictionaryConfigurationHandler.java
@@ -51,7 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import gov.pnnl.goss.cim2glm.CIMImporter;
-import gov.pnnl.goss.cim2glm.components.ModelState;
+import gov.pnnl.goss.cim2glm.ModelState;
 import gov.pnnl.goss.cim2glm.queryhandler.QueryHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationManager;

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/CIMDictionaryConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/CIMDictionaryConfigurationHandler.java
@@ -50,6 +50,8 @@ import org.apache.felix.dm.annotation.api.Start;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.Gson;
+
 import gov.pnnl.goss.cim2glm.CIMImporter;
 import gov.pnnl.goss.cim2glm.dto.ModelState;
 import gov.pnnl.goss.cim2glm.queryhandler.QueryHandler;
@@ -61,6 +63,7 @@ import gov.pnnl.goss.gridappsd.api.PowergridModelDataManager;
 import gov.pnnl.goss.gridappsd.api.SimulationManager;
 import gov.pnnl.goss.gridappsd.data.handlers.BlazegraphQueryHandler;
 import gov.pnnl.goss.gridappsd.dto.LogMessage.LogLevel;
+import gov.pnnl.goss.gridappsd.dto.ConfigurationRequest;
 import gov.pnnl.goss.gridappsd.dto.SimulationContext;
 import gov.pnnl.goss.gridappsd.utils.GridAppsDConstants;
 import pnnl.goss.core.Client;
@@ -117,13 +120,10 @@ public class CIMDictionaryConfigurationHandler extends BaseConfigurationHandler 
 		boolean useHouses = false;
 		if(parameters.containsKey(USEHOUSES))
 			useHouses = GridAppsDConstants.getBooleanProperty(parameters, USEHOUSES, false);
-        ModelState modelState = new ModelState();
 		File configFile = null;
 		if(simulationId!=null){
 			SimulationContext simulationContext = simulationManager.getSimulationContextForId(simulationId);
 			if(simulationContext!=null){
-				modelState = simulationContext.getModelState();
-				
 				configFile = new File(simulationContext.getSimulationDir()+File.separator+GLDAllConfigurationHandler.DICTIONARY_FILENAME);
 				//If the config file already has been created for this simulation then return it
 				if(configFile.exists()){
@@ -136,7 +136,15 @@ public class CIMDictionaryConfigurationHandler extends BaseConfigurationHandler 
 			}
 		}
 		
-		
+        ModelState modelState = new ModelState();
+		String modelStateStr = GridAppsDConstants.getStringProperty(parameters, MODELSTATE, null);
+		if(modelStateStr==null || modelStateStr.trim().length()==0){
+			logRunning("No "+MODELSTATE+" parameter provided", processId, username, logManager);
+		} else {
+			Gson  gson = new Gson();
+			modelState = gson.fromJson(modelStateStr, ModelState.class);
+		}
+
 		String modelId = GridAppsDConstants.getStringProperty(parameters, MODELID, null);
 		if(modelId==null || modelId.trim().length()==0){
 			logError("No "+MODELID+" parameter provided", processId, username, logManager);

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/DSSAllConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/DSSAllConfigurationHandler.java
@@ -40,6 +40,7 @@
 package gov.pnnl.goss.gridappsd.configuration;
 
 import gov.pnnl.goss.cim2glm.CIMImporter;
+import gov.pnnl.goss.cim2glm.components.ModelState;
 import gov.pnnl.goss.cim2glm.queryhandler.QueryHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationManager;
@@ -49,6 +50,7 @@ import gov.pnnl.goss.gridappsd.api.PowergridModelDataManager;
 import gov.pnnl.goss.gridappsd.api.SimulationManager;
 import gov.pnnl.goss.gridappsd.data.handlers.BlazegraphQueryHandler;
 import gov.pnnl.goss.gridappsd.dto.SimulationContext;
+import gov.pnnl.goss.gridappsd.dto.LogMessage.LogLevel;
 import gov.pnnl.goss.gridappsd.utils.GridAppsDConstants;
 
 import java.io.File;
@@ -186,6 +188,17 @@ public class DSSAllConfigurationHandler extends BaseConfigurationHandler impleme
 		}catch (Exception e) {
 			logError("Simulation ID not a valid integer "+simulationID+", defaulting to "+simId, simulationID, username, logManager);
 		}
+		
+		ModelState modelState = new ModelState();
+		if(simulationID!=null){
+			SimulationContext simulationContext = simulationManager.getSimulationContextForId(simulationID);
+			if(simulationContext!=null){
+				modelState = simulationContext.getModelState();
+			} else {
+				logRunning("No simulation context found for simulation_id: "+simulationID, processId, username, logManager, LogLevel.WARN);
+			}
+		}
+		
 		long simulationStartTime = GridAppsDConstants.getLongProperty(parameters, SIMULATIONSTARTTIME, -1);
 		if(simulationStartTime<0){
 			logError("No "+SIMULATIONSTARTTIME+" parameter provided", processId, username, logManager);
@@ -214,7 +227,7 @@ public class DSSAllConfigurationHandler extends BaseConfigurationHandler impleme
 		
 		//CIM2GLM utility uses 
 		CIMImporter cimImporter = new CIMImporter(); 
-		cimImporter.start(queryHandler, CONFIGTARGET, fRoot, scheduleName, loadScale, bWantSched, bWantZip, bWantRandomFractions, useHouses, zFraction, iFraction, pFraction, bHaveEventGen);
+		cimImporter.start(queryHandler, CONFIGTARGET, fRoot, scheduleName, loadScale, bWantSched, bWantZip, bWantRandomFractions, useHouses, zFraction, iFraction, pFraction, bHaveEventGen, modelState);
 		
 		logRunning("Finished generating all DSS configuration files.", processId, username, logManager);
 		

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/DSSAllConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/DSSAllConfigurationHandler.java
@@ -40,7 +40,7 @@
 package gov.pnnl.goss.gridappsd.configuration;
 
 import gov.pnnl.goss.cim2glm.CIMImporter;
-import gov.pnnl.goss.cim2glm.ModelState;
+import gov.pnnl.goss.cim2glm.dto.ModelState;
 import gov.pnnl.goss.cim2glm.queryhandler.QueryHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationManager;

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/DSSAllConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/DSSAllConfigurationHandler.java
@@ -40,7 +40,7 @@
 package gov.pnnl.goss.gridappsd.configuration;
 
 import gov.pnnl.goss.cim2glm.CIMImporter;
-import gov.pnnl.goss.cim2glm.components.ModelState;
+import gov.pnnl.goss.cim2glm.ModelState;
 import gov.pnnl.goss.cim2glm.queryhandler.QueryHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationManager;

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/DSSAllConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/DSSAllConfigurationHandler.java
@@ -63,6 +63,8 @@ import org.apache.felix.dm.annotation.api.Start;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.Gson;
+
 import pnnl.goss.core.Client;
 
 
@@ -189,15 +191,14 @@ public class DSSAllConfigurationHandler extends BaseConfigurationHandler impleme
 			logError("Simulation ID not a valid integer "+simulationID+", defaulting to "+simId, simulationID, username, logManager);
 		}
 		
-		ModelState modelState = new ModelState();
-		if(simulationID!=null){
-			SimulationContext simulationContext = simulationManager.getSimulationContextForId(simulationID);
-			if(simulationContext!=null){
-				modelState = simulationContext.getModelState();
-			} else {
-				logRunning("No simulation context found for simulation_id: "+simulationID, processId, username, logManager, LogLevel.WARN);
-			}
-		}
+		 ModelState modelState = new ModelState();
+		 String modelStateStr = GridAppsDConstants.getStringProperty(parameters, MODELSTATE, null);
+		 if(modelStateStr==null || modelStateStr.trim().length()==0){
+			 logRunning("No "+MODELSTATE+" parameter provided", processId, username, logManager);
+		 } else {
+			 Gson  gson = new Gson();
+			 modelState = gson.fromJson(modelStateStr, ModelState.class);
+		 }
 		
 		long simulationStartTime = GridAppsDConstants.getLongProperty(parameters, SIMULATIONSTARTTIME, -1);
 		if(simulationStartTime<0){

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDAllConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDAllConfigurationHandler.java
@@ -56,6 +56,7 @@ import org.apache.jena.query.ResultSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
 import gov.pnnl.goss.cim2glm.CIMImporter;
@@ -115,6 +116,7 @@ public class GLDAllConfigurationHandler extends BaseConfigurationHandler impleme
 	public static final String SIMULATIONBROKERPORT = "simulation_broker_port";
 	public static final String STARTTIME_FILTER = "startTime";
 	public static final String ENDTIME_FILTER = "endTime";
+	public static final String MODEL_STATE = "model_state";
 	public static final int TIMEFILTER_YEAR = 2013;
 
 	public static final String CONFIGTARGET = "glm";
@@ -205,15 +207,13 @@ public class GLDAllConfigurationHandler extends BaseConfigurationHandler impleme
 		}
 		
 		ModelState modelState = new ModelState();
-		if(simulationID!=null){
-			SimulationContext simulationContext = simulationManager.getSimulationContextForId(simulationID);
-			if(simulationContext!=null){
-				modelState = simulationContext.getModelState();
-			} else {
-				logRunning("No simulation context found for simulation_id: "+simulationID, processId, username, logManager, LogLevel.WARN);
-			}
-		}
-		
+		String modelStateStr = GridAppsDConstants.getStringProperty(parameters, MODELSTATE, null);
+		if(modelStateStr==null || modelStateStr.trim().length()==0){
+			logRunning("No "+MODELSTATE+" parameter provided", processId, username, logManager);
+		} else {
+			Gson  gson = new Gson();
+			modelState = gson.fromJson(modelStateStr, ModelState.class);
+		}		
 		
 		long simulationStartTime = GridAppsDConstants.getLongProperty(parameters, SIMULATIONSTARTTIME, -1);
 		if(simulationStartTime<0){

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDAllConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDAllConfigurationHandler.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.JsonSyntaxException;
 
 import gov.pnnl.goss.cim2glm.CIMImporter;
-import gov.pnnl.goss.cim2glm.components.ModelState;
+import gov.pnnl.goss.cim2glm.ModelState;
 import gov.pnnl.goss.cim2glm.queryhandler.QueryHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationManager;

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDAllConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDAllConfigurationHandler.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.JsonSyntaxException;
 
 import gov.pnnl.goss.cim2glm.CIMImporter;
-import gov.pnnl.goss.cim2glm.ModelState;
+import gov.pnnl.goss.cim2glm.dto.ModelState;
 import gov.pnnl.goss.cim2glm.queryhandler.QueryHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationManager;

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
@@ -136,12 +136,9 @@ public class GLDSimulationOutputConfigurationHandler extends BaseConfigurationHa
 		String simulationId = GridAppsDConstants.getStringProperty(parameters, SIMULATIONID, null);
 		boolean useHouses = GridAppsDConstants.getBooleanProperty(parameters, USEHOUSES, false);
 		File configFile = null;
-		ModelState modelState = new ModelState();
 		if(simulationId!=null){
 			SimulationContext simulationContext = simulationManager.getSimulationContextForId(simulationId);
 			if(simulationContext!=null){
-				modelState = simulationContext.getModelState();
-				
 				configFile = new File(simulationContext.getSimulationDir()+File.separator+GLDAllConfigurationHandler.MEASUREMENTOUTPUTS_FILENAME);
 				dictFile = new File(simulationContext.getSimulationDir()+File.separator+GLDAllConfigurationHandler.DICTIONARY_FILENAME);
 				//If the config file already has been created for this simulation then return it
@@ -161,6 +158,14 @@ public class GLDSimulationOutputConfigurationHandler extends BaseConfigurationHa
 			throw new Exception("Missing parameter "+MODELID);
 		}
 		
+		ModelState modelState = new ModelState();
+		String modelStateStr = GridAppsDConstants.getStringProperty(parameters, MODELSTATE, null);
+		if(modelStateStr==null || modelStateStr.trim().length()==0){
+			logRunning("No "+MODELSTATE+" parameter provided", processId, username, logManager);
+		} else {
+			Gson  gson = new Gson();
+			modelState = gson.fromJson(modelStateStr, ModelState.class);
+		}
 		//If passed in, use location of dictionary file, otherwise it will attempt to generate it
 		String dictFilePath = GridAppsDConstants.getStringProperty(parameters, DICTIONARY_FILE, null);
 		if(dictFilePath!=null){

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
@@ -68,6 +68,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 
 import gov.pnnl.goss.cim2glm.CIMImporter;
+import gov.pnnl.goss.cim2glm.components.ModelState;
 import gov.pnnl.goss.cim2glm.queryhandler.QueryHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationManager;
@@ -135,9 +136,12 @@ public class GLDSimulationOutputConfigurationHandler extends BaseConfigurationHa
 		String simulationId = GridAppsDConstants.getStringProperty(parameters, SIMULATIONID, null);
 		boolean useHouses = GridAppsDConstants.getBooleanProperty(parameters, USEHOUSES, false);
 		File configFile = null;
+		ModelState modelState = new ModelState();
 		if(simulationId!=null){
 			SimulationContext simulationContext = simulationManager.getSimulationContextForId(simulationId);
 			if(simulationContext!=null){
+				modelState = simulationContext.getModelState();
+				
 				configFile = new File(simulationContext.getSimulationDir()+File.separator+GLDAllConfigurationHandler.MEASUREMENTOUTPUTS_FILENAME);
 				dictFile = new File(simulationContext.getSimulationDir()+File.separator+GLDAllConfigurationHandler.DICTIONARY_FILENAME);
 				//If the config file already has been created for this simulation then return it
@@ -182,7 +186,7 @@ public class GLDSimulationOutputConfigurationHandler extends BaseConfigurationHa
 			StringWriter dictionaryStringOutput = new StringWriter();
 			PrintWriter dictionaryOutput = new PrintWriter(dictionaryStringOutput);
 			
-			cimImporter.generateDictionaryFile(queryHandler, dictionaryOutput, useHouses);
+			cimImporter.generateDictionaryFile(queryHandler, dictionaryOutput, useHouses, modelState);
 			String dictOut = dictionaryStringOutput.toString();
 			measurementFileReader = null;
 			if(dictFile!=null && dictFile.getName().length()>0 && !dictFile.exists()){

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
@@ -68,7 +68,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 
 import gov.pnnl.goss.cim2glm.CIMImporter;
-import gov.pnnl.goss.cim2glm.ModelState;
+import gov.pnnl.goss.cim2glm.dto.ModelState;
 import gov.pnnl.goss.cim2glm.queryhandler.QueryHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationManager;

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
@@ -68,7 +68,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 
 import gov.pnnl.goss.cim2glm.CIMImporter;
-import gov.pnnl.goss.cim2glm.components.ModelState;
+import gov.pnnl.goss.cim2glm.ModelState;
 import gov.pnnl.goss.cim2glm.queryhandler.QueryHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationHandler;
 import gov.pnnl.goss.gridappsd.api.ConfigurationManager;

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/ModelCreationConfig.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/ModelCreationConfig.java
@@ -44,6 +44,8 @@ import java.io.Serializable;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
+import gov.pnnl.goss.cim2glm.ModelState;
+
 public class ModelCreationConfig implements Serializable{
 
 	private static final long serialVersionUID = 1L;
@@ -61,7 +63,8 @@ public class ModelCreationConfig implements Serializable{
 	public double p_fraction = 0;  // allowed values {0....1}  constant P portion (defaults to 0 for CIM-defined,  maps to -p
 	public boolean randomize_zipload_fractions = false; // should randomize the zipload fraction values (eg. z, i, p_fractions)
 	public boolean use_houses = false;  
-	
+	public ModelState model_state;
+
 	
 	
 	
@@ -150,6 +153,13 @@ public class ModelCreationConfig implements Serializable{
 		return gson.toJson(this);
 	}
 	
+	public ModelState getModel_state() {
+		return model_state;
+	}
+	public void setModel_state(ModelState model_state) {
+		this.model_state = model_state;
+	}
+	
 	public static ModelCreationConfig parse(String jsonString){
 		Gson  gson = new Gson();
 		ModelCreationConfig obj = gson.fromJson(jsonString, ModelCreationConfig.class);
@@ -157,6 +167,5 @@ public class ModelCreationConfig implements Serializable{
 			throw new JsonSyntaxException("Expected attribute schedule_name not found");
 		return obj;
 	}
-	
 	
 }

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/ModelCreationConfig.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/ModelCreationConfig.java
@@ -44,7 +44,7 @@ import java.io.Serializable;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
-import gov.pnnl.goss.cim2glm.ModelState;
+import gov.pnnl.goss.cim2glm.dto.ModelState;
 
 public class ModelCreationConfig implements Serializable{
 

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/SimulationConfig.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/SimulationConfig.java
@@ -44,7 +44,7 @@ import java.io.Serializable;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
-import gov.pnnl.goss.cim2glm.components.ModelState;
+import gov.pnnl.goss.cim2glm.ModelState;
 
 public class SimulationConfig  implements Serializable {
 	private static final long serialVersionUID = -2995486912804104569L;

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/SimulationConfig.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/SimulationConfig.java
@@ -44,6 +44,8 @@ import java.io.Serializable;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
+import gov.pnnl.goss.cim2glm.components.ModelState;
+
 public class SimulationConfig  implements Serializable {
 	private static final long serialVersionUID = -2995486912804104569L;
 
@@ -65,6 +67,8 @@ public class SimulationConfig  implements Serializable {
 	
 	//Slow simulator down to realtime if true.  If false it will run as fast as the simulator allows
 	public boolean run_realtime = true;
+	
+	public ModelState model_state;
 
 	//eg "simulation_output": [{"name":"objectname", "properties": ["prop1","prop2"]},{"name":"object2name","properties":["prop1","prop2"]}]
 	public SimulationOutput simulation_output = new SimulationOutput();
@@ -169,6 +173,12 @@ public class SimulationConfig  implements Serializable {
 		return gson.toJson(this);
 	}
 	
+	public ModelState getModel_state() {
+		return model_state;
+	}
+	public void setModel_state(ModelState model_state) {
+		this.model_state = model_state;
+	}
 	public static SimulationConfig parse(String jsonString){
 		Gson  gson = new Gson();
 		SimulationConfig obj = gson.fromJson(jsonString, SimulationConfig.class);

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/SimulationConfig.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/SimulationConfig.java
@@ -44,7 +44,6 @@ import java.io.Serializable;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
-import gov.pnnl.goss.cim2glm.ModelState;
 
 public class SimulationConfig  implements Serializable {
 	private static final long serialVersionUID = -2995486912804104569L;
@@ -68,7 +67,6 @@ public class SimulationConfig  implements Serializable {
 	//Slow simulator down to realtime if true.  If false it will run as fast as the simulator allows
 	public boolean run_realtime = true;
 	
-	public ModelState model_state;
 
 	//eg "simulation_output": [{"name":"objectname", "properties": ["prop1","prop2"]},{"name":"object2name","properties":["prop1","prop2"]}]
 	public SimulationOutput simulation_output = new SimulationOutput();
@@ -173,12 +171,7 @@ public class SimulationConfig  implements Serializable {
 		return gson.toJson(this);
 	}
 	
-	public ModelState getModel_state() {
-		return model_state;
-	}
-	public void setModel_state(ModelState model_state) {
-		this.model_state = model_state;
-	}
+	
 	public static SimulationConfig parse(String jsonString){
 		Gson  gson = new Gson();
 		SimulationConfig obj = gson.fromJson(jsonString, SimulationConfig.class);

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/SimulationContext.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/SimulationContext.java
@@ -3,7 +3,6 @@ package gov.pnnl.goss.gridappsd.dto;
 import java.io.Serializable;
 import java.util.List;
 
-import gov.pnnl.goss.cim2glm.dto.ModelState;
 
 public class SimulationContext implements Serializable {
 
@@ -19,7 +18,6 @@ public class SimulationContext implements Serializable {
 	public List<String> appInstanceIds;
 	public List<String> serviceInstanceIds;
 	public String simulationUser;
-	public ModelState modelState = new ModelState();
 
 	public String getSimulationId() {
 		return simulationId;
@@ -105,14 +103,5 @@ public class SimulationContext implements Serializable {
 		this.simulationUser = simulationUser;
 	}
 
-	public ModelState getModelState() {
-		return modelState;
-	}
-
-	public void setModelState(ModelState modelState) {
-		this.modelState = modelState;
-	}
-	
-	
 
 }

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/SimulationContext.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/SimulationContext.java
@@ -3,7 +3,7 @@ package gov.pnnl.goss.gridappsd.dto;
 import java.io.Serializable;
 import java.util.List;
 
-import gov.pnnl.goss.cim2glm.ModelState;
+import gov.pnnl.goss.cim2glm.dto.ModelState;
 
 public class SimulationContext implements Serializable {
 

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/SimulationContext.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/SimulationContext.java
@@ -3,7 +3,7 @@ package gov.pnnl.goss.gridappsd.dto;
 import java.io.Serializable;
 import java.util.List;
 
-import gov.pnnl.goss.cim2glm.components.ModelState;
+import gov.pnnl.goss.cim2glm.ModelState;
 
 public class SimulationContext implements Serializable {
 

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/SimulationContext.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/SimulationContext.java
@@ -3,6 +3,8 @@ package gov.pnnl.goss.gridappsd.dto;
 import java.io.Serializable;
 import java.util.List;
 
+import gov.pnnl.goss.cim2glm.components.ModelState;
+
 public class SimulationContext implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -17,7 +19,7 @@ public class SimulationContext implements Serializable {
 	public List<String> appInstanceIds;
 	public List<String> serviceInstanceIds;
 	public String simulationUser;
-	
+	public ModelState modelState = new ModelState();
 
 	public String getSimulationId() {
 		return simulationId;
@@ -101,6 +103,14 @@ public class SimulationContext implements Serializable {
 
 	public void setSimulationUser(String simulationUser) {
 		this.simulationUser = simulationUser;
+	}
+
+	public ModelState getModelState() {
+		return modelState;
+	}
+
+	public void setModelState(ModelState modelState) {
+		this.modelState = modelState;
 	}
 	
 	

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessNewSimulationRequest.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessNewSimulationRequest.java
@@ -382,9 +382,10 @@ public class ProcessNewSimulationRequest {
 		params.put(GLDAllConfigurationHandler.SIMULATIONSTARTTIME, requestSimulation.getSimulation_config().start_time);
 		params.put(GLDAllConfigurationHandler.SIMULATIONDURATION, new Integer(requestSimulation.getSimulation_config().duration).toString());
 		
-		Gson  gson = new Gson();
-		params.put(GLDAllConfigurationHandler.MODEL_STATE, gson.toJson(modelConfig.getModel_state()));
-
+		if(modelConfig.getModel_state()!=null){
+			Gson  gson = new Gson();
+			params.put(GLDAllConfigurationHandler.MODEL_STATE, gson.toJson(modelConfig.getModel_state()));
+		}
 		return params;
 	}
 

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessNewSimulationRequest.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessNewSimulationRequest.java
@@ -74,6 +74,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import com.google.gson.Gson;
+
 import pnnl.goss.core.DataResponse;
 
 public class ProcessNewSimulationRequest {
@@ -169,7 +171,6 @@ public class ProcessNewSimulationRequest {
 			simContext.simulationPort = simulationPort;
 			simContext.simulationDir = tempDataPathDir.getAbsolutePath();
 			simContext.startupFile = tempDataPathDir.getAbsolutePath()+File.separator+"model_startup.glm";
-			simContext.modelState = simRequest.getSimulation_config().model_creation_config.getModel_state();
 			simContext.simulationUser = username;
 			try{
 				simContext.simulatorPath = serviceManager.getService(simRequest.getSimulation_config().getSimulator()).getExecution_path();
@@ -189,7 +190,6 @@ public class ProcessNewSimulationRequest {
 				}
 				e.printStackTrace();
 			}
-
 
 
 
@@ -381,6 +381,9 @@ public class ProcessNewSimulationRequest {
 
 		params.put(GLDAllConfigurationHandler.SIMULATIONSTARTTIME, requestSimulation.getSimulation_config().start_time);
 		params.put(GLDAllConfigurationHandler.SIMULATIONDURATION, new Integer(requestSimulation.getSimulation_config().duration).toString());
+		
+		Gson  gson = new Gson();
+		params.put(GLDAllConfigurationHandler.MODEL_STATE, gson.toJson(modelConfig.getModel_state()));
 
 		return params;
 	}

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessNewSimulationRequest.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessNewSimulationRequest.java
@@ -169,6 +169,7 @@ public class ProcessNewSimulationRequest {
 			simContext.simulationPort = simulationPort;
 			simContext.simulationDir = tempDataPathDir.getAbsolutePath();
 			simContext.startupFile = tempDataPathDir.getAbsolutePath()+File.separator+"model_startup.glm";
+			simContext.modelState = simRequest.simulation_config.getModel_state();
 			System.out.println("SET USERNAME FOR SIMCONTEXT "+username);
 			simContext.simulationUser = username;
 			try{

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessNewSimulationRequest.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessNewSimulationRequest.java
@@ -169,8 +169,7 @@ public class ProcessNewSimulationRequest {
 			simContext.simulationPort = simulationPort;
 			simContext.simulationDir = tempDataPathDir.getAbsolutePath();
 			simContext.startupFile = tempDataPathDir.getAbsolutePath()+File.separator+"model_startup.glm";
-			simContext.modelState = simRequest.simulation_config.getModel_state();
-			System.out.println("SET USERNAME FOR SIMCONTEXT "+username);
+			simContext.modelState = simRequest.getSimulation_config().model_creation_config.getModel_state();
 			simContext.simulationUser = username;
 			try{
 				simContext.simulatorPath = serviceManager.getService(simRequest.getSimulation_config().getSimulator()).getExecution_path();


### PR DESCRIPTION
# Description

Also known as the box between the boxes, this takes a json object (like below) that specifies the desired state for switches and generators and updates the model in memory before it is written out to the simulation config files in the cim2glm code.  This json would be added to the model configuration text box during the simulation setup.

Until the PowergridModels pull request is approved you will need to change the branch in repositories.bnd to use 'model_state2' instead of develop  (eg.	aQute.bnd.deployer.repository.FixedIndexedRepo;name=CIM to GLM;locations=https://raw.githubusercontent.com/GRIDAPPSD/Powergrid-Models/model_state2/cnf/release/index.xml,\)


"model_state":{
  "synchronousmachines":[
    {"name":"diesel590","p":1000.000,"q":140.000},
    {"name":"diesel620","p":150.000,"q":500.000}
  ],
  "switches":[
    {"name":"2002200004641085_sw","open":true},
    {"name":"2002200004868472_sw","open":true},
    {"name":"l9407_48332_sw","open":true},
	{"name":"tsw568613_sw","open":false}
  ]
}



