### PR TITLE
Fncs archive

### DIFF
--- a/services/GridLAB-D.config
+++ b/services/GridLAB-D.config
@@ -8,7 +8,7 @@
 	"execution_path": "gridlabd.sh",
 	"type": "EXE",
 	"launch_on_startup": "false",
-	"service_dependencies": ["fncs","fncsgossbridge","gridappsd-alarms","gridappsd-voltage-violation"],
+	"service_dependencies": ["fncs","fncsgossbridge"],
 	"multiple_instances": "true",
 	"environmentVariables":[]
 }

--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -292,6 +292,10 @@ class GOSSListener(object):
         self.simulation_start = sim_start
         self.simulation_time = 0
         self.measurement_filter = []
+        filter_file = "/tmp/filter.json"
+        if os.path.exists(filter_file):
+            with open(filter_file) as fp:
+                self.measurement_filter = json.loads(fp.read())
         self.command_filter = []
         self.filter_all_commands = False
         self.filter_all_measurements = False

--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -221,6 +221,8 @@ def create_schema(conn):
         FOREIGN KEY (measurement_id)
             REFERENCES measurement_props (measurement_id)         
     );
+    
+    CREATE INDEX timestamp_indx ON measurements(timestamp);
     """
     cursor = db_connection.cursor()
     for d in sql.split(';'):


### PR DESCRIPTION
# Description

Allows output of an archive.tar.gz file or archive.sqlite3 database output either in addition to or instead of outputting data to the message bus.  The archives will be plased in the simulation folder for each simulation run if one of simulation_config parameters are available (NOTE currently the simulation manager or something strips out unknown parameters)  

- make_archive           -  Defaults to false
- make_db_archive     - Defaults to false
- only_archive             - Defaults to false

This archive or tar file can then be used to "play" data without the need to re-simulate it.  The speed of data from the player is much faster than the simulation of the 9500 node system. 

The docker container with these changes can be found at:
- craig8/gridappsd:fncs_archive

enter the docker container and edit the file: /gridappsd/services/fncsgossbridge/service/fncs_goss_bridge.py

The options are at the bottom of the file.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested by modifying each of the parameters that could be sent with a simulation to make sure that all three parameters (make_db_archive, make_archive, and only_archive) work harmoniously together.

