### PR TITLE
Multiple service instance

### DIFF
--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/api/ServiceManager.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/api/ServiceManager.java
@@ -90,7 +90,7 @@ public interface ServiceManager {
 	 * Start service instance
 	 * @param service_id  Registered ID of the desired service
 	 * @param runtimeOptions Runtime options for the service instance, in most cases these will be passed in on the command-line 
-	 * @return String containing service instance ID
+	 * @return String containing service instance ID or null if service is already started for that simulation
 	 */
 	String startService(String service_id, HashMap<String, Object> runtimeOptions);  //may also need input/output topics or simulation id
 	
@@ -111,9 +111,10 @@ public interface ServiceManager {
 	/**
 	 * Lists currently running service instances for the requested service ID
 	 * @param serviceId  Registered ID of the service to list
+	 * @param simulationId Id of the simulation
 	 * @return List of ServiceInstance objects
 	 */
-	List<ServiceInstance> listRunningServices(String serviceId);
+	List<ServiceInstance> listRunningServices(String serviceId, String simulationId);
 
 	/**
 	 * Stops service instance

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessNewSimulationRequest.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessNewSimulationRequest.java
@@ -294,13 +294,15 @@ public class ProcessNewSimulationRequest {
 
 						if(!connectServiceIds.contains(prereqs)){
 							String serviceInstanceId = serviceManager.startServiceForSimultion(prereqs, null,simulationContext);
-							connectServiceInstanceIds.add(serviceInstanceId);
-							logManager.log(new LogMessage(source, simId, new Date().getTime(),"Started "
+							if(serviceInstanceId!=null){
+								connectServiceInstanceIds.add(serviceInstanceId);
+								logManager.log(new LogMessage(source, simId, new Date().getTime(),"Started "
 									+ prereqs + " with instance id "
 									+ serviceInstanceId,LogLevel.DEBUG, ProcessStatus.RUNNING, true),
 									username,
 									GridAppsDConstants.topic_simulationLog
 											+ simulationId);
+							}
 						}
 					}
 

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessNewSimulationRequest.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessNewSimulationRequest.java
@@ -256,8 +256,10 @@ public class ProcessNewSimulationRequest {
 			else{
 				for(ServiceConfig serviceConfig : simRequest.service_configs){
 					String serviceInstanceId = serviceManager.startServiceForSimultion(serviceConfig.getId(), null, simulationContext);
-					connectServiceInstanceIds.add(serviceInstanceId);
-					connectServiceIds.add(serviceConfig.getId());
+					if(serviceInstanceId!=null){
+						connectServiceInstanceIds.add(serviceInstanceId);
+						connectServiceIds.add(serviceConfig.getId());
+					}
 				}
 			}
 			

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/service/ServiceManagerImpl.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/service/ServiceManagerImpl.java
@@ -262,9 +262,15 @@ public class ServiceManagerImpl implements ServiceManager{
 			throw new RuntimeException("Service not found: "+serviceId);
 		}
 		
-		// are multiple allowed? if not check to see if it is already running, if it is then fail
-		if(!serviceInfo.isMultiple_instances() && listRunningServices(serviceId).size()>0){
-			throw new RuntimeException("Service is already running and multiple instances are not allowed: "+serviceId);
+		// are multiple allowed? if not check to see if it is already running, if it is then send warning message
+		if(!serviceInfo.isMultiple_instances() && listRunningServices(serviceId, simulationId).size()>0){
+			logManager.log(new LogMessage(this.getClass().getSimpleName(), 
+					simulationId, new Date().getTime(),
+					serviceId + " service is already running and multiple instances are not allowed for single simulation", 
+					LogLevel.WARN, ProcessStatus.RUNNING, true), 
+					securityConfig.getManagerUser(),
+					GridAppsDConstants.topic_simulationLog+simulationId);
+			return null;
 		}
 
 		File serviceDirectory = new File(getServiceConfigDirectory().getAbsolutePath()
@@ -433,12 +439,15 @@ public class ServiceManagerImpl implements ServiceManager{
 	}
 	
 	@Override
-	public List<ServiceInstance> listRunningServices(String serviceId) {
+	public List<ServiceInstance> listRunningServices(String serviceId, String simulationId) {
 		List<ServiceInstance> result = new ArrayList<ServiceInstance>();
 		for(String instanceId: serviceInstances.keySet()){
 			ServiceInstance instance = serviceInstances.get(instanceId);
 			if(instance.getService_info().getId().equals(serviceId)){
-				result.add(instance);
+				if(simulationId!=null && instance.getSimulation_id().equals(simulationId))
+					result.add(instance);
+				else
+					result.add(instance);
 			}
 		}
 		return result;
@@ -447,7 +456,7 @@ public class ServiceManagerImpl implements ServiceManager{
 	@Override
 	public void stopService(String serviceId) {
 		serviceId = serviceId.trim();
-		for(ServiceInstance instance: listRunningServices(serviceId)){
+		for(ServiceInstance instance: listRunningServices(serviceId, null)){
 			if(instance.getService_info().getId().equals(serviceId)){
 				stopServiceInstance(instance.getInstance_id());
 			}

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/simulation/SimulationManagerImpl.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/simulation/SimulationManagerImpl.java
@@ -208,7 +208,8 @@ public class SimulationManagerImpl implements SimulationManager{
 		List<String> serviceDependencies = simulationServiceInfo.getService_dependencies();
 		for(String service : serviceDependencies) {
 			String serviceInstanceId = serviceManager.startServiceForSimultion(service, null, simulationContext);
-			simContext.addServiceInstanceIds(serviceInstanceId);
+			if(serviceInstanceId!=null)
+				simContext.addServiceInstanceIds(serviceInstanceId);
 		}
 		
 	}

--- a/services/GridLAB-D.config
+++ b/services/GridLAB-D.config
@@ -9,6 +9,6 @@
 	"type": "EXE",
 	"launch_on_startup": "false",
 	"service_dependencies": ["fncs","fncsgossbridge","gridappsd-alarms","gridappsd-voltage-violation"],
-	"multiple_instances": "true",
+	"multiple_instances": false,
 	"environmentVariables":[]
 }

--- a/services/fncs.config
+++ b/services/fncs.config
@@ -9,6 +9,6 @@
 	"type": "EXE",
 	"launch_on_startup": "false",
 	"prereqs": [],
-	"multiple_instances": "true",
+	"multiple_instances": false,
 	"environmentVariables":[{"envName":"FNCS_FATAL","envValue":false},{"envName":"FNCS_BROKER","envValue":"tcp://*:(simulationPort)"}]
 }

--- a/services/fncsgossbridge.config
+++ b/services/fncsgossbridge.config
@@ -9,6 +9,6 @@
 	"type": "PYTHON",
 	"launch_on_startup": "false",
 	"prereqs": ["fncs"],
-	"multiple_instances": "true",
+	"multiple_instances": false,
 	"environmentVariables":[{"envName":"FNCS_FATAL","envValue":false}]
 }


### PR DESCRIPTION
Some applications have fncs , fncsgossbridge, alarms service and voltage violation service as prereqs. These are prereqs for GridLAB-D already. So the platform is trying to start them twice. 
Made changes to not start the service twice, throw a warning message and continue with simulation. 