### PR TITLE
feature 1201 PR

### DIFF
--- a/gov.pnnl.goss.gridappsd/bnd.bnd
+++ b/gov.pnnl.goss.gridappsd/bnd.bnd
@@ -29,7 +29,7 @@
 	osgi.enroute.base.api,\
 	org.mockito.mockito-all,\
 	httpcore,\
-	blazegraph.cim2glm;version=18.0.0,\
+	blazegraph.cim2glm;version=18.0.1,\
 	httpclient,\
 	com.bigdata.rdf,\
     proven-client;version=0.2.3,\

--- a/gov.pnnl.goss.gridappsd/run.bnd.bndrun
+++ b/gov.pnnl.goss.gridappsd/run.bnd.bndrun
@@ -74,7 +74,7 @@
 	httpcore,\
 	httpclient,\
 	xml-apis,\
-	blazegraph.cim2glm;version=18.0.0,\
+	blazegraph.cim2glm;version=18.0.1,\
 	org.eclipse.jetty.aggregate.jetty-all-server;version=7.6.9,\
 	javax.servlet-api,\
 	com.bigdata.rdf,\

--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -205,6 +205,9 @@ difference_attribute_map = {
         "triplex_load" : {
             "property" : ["base_power_{}"],
             "prefix" : "ld_"
+        },
+        "load" : {
+            "property" : ["base_power_{}"]
         }
     }
 }
@@ -733,8 +736,17 @@ def _publish_to_fncs_bus(simulation_id, goss_message, command_filter):
                         for y in object_phases:
                             fncs_input_message["{}".format(simulation_id)][object_name_prefix + object_name][object_property_list[0]] = float(x.get("value"))
                     elif cim_attribute == "EnergyConsumer.p":
-                        for y in ["1","2"]:
-                            fncs_input_messag["{}".format(simulation_id)][object_name_prefix + object_name][object_property_list[0].format(y)] = float(x.get("value"))/2.0
+                        phase_count = len(object_phases)
+                        if "s1" in object_phases:
+                            fncs_input_message["{}".format(simulation_id)][object_name_prefix + object_name][object_property_list[0].format("1")] = float(x.get("value"))/phase_count
+                        if "s2" in object_phases:
+                            fncs_input_message["{}".format(simulation_id)][object_name_prefix + object_name][object_property_list[0].format("2")] = float(x.get("value"))/phase_count
+                        if "A" in object_phases:
+                            fncs_input_message["{}".format(simulation_id)][object_name_prefix + object_name][object_property_list[0].format("A")] = float(x.get("value"))/phase_count
+                        if "B" in object_phases:
+                            fncs_input_message["{}".format(simulation_id)][object_name_prefix + object_name][object_property_list[0].format("B")] = float(x.get("value"))/phase_count
+                        if "C" in object_phases:
+                            fncs_input_message["{}".format(simulation_id)][object_name_prefix + object_name][object_property_list[0].format("C")] = float(x.get("value"))/phase_count
                     else:
                         _send_simulation_status("RUNNING", "Attribute, {}, is not a supported attribute in the simulator at this current time. ignoring difference.", "WARN")
     
@@ -1321,9 +1333,12 @@ def _create_cim_object_map(map_file=None):
                         "name" : y.get("name"),
                         "phases" : y.get("phases"),
                         "total_phases" : y.get("phases"),
-                        "type" : "triplex_load",
                         "prefix" : "ld_"
                     }
+                    if "s1" in object_mrid_to_name[y.get("mRID")]["phases"] or "s2" in object_mrid_to_name[y.get("mRID")]["phases"]:
+                        object_mrid_to_name[y.get("mRID")]["type"] = "triplex_load"
+                    else:
+                        object_mrid_to_name[y.get("mRID")]["type"] = "load"
         except Exception as e:
             _send_simulation_status('STARTED', "The measurement map file, {}, couldn't be translated.\nError:{}".format(map_file, e), 'ERROR')
             pass

--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -200,6 +200,12 @@ difference_attribute_map = {
             "property" : ["compensator_x_setting_{}"],
             "prefix" : "rcon_"
         }
+    },
+    "EnergyConsumer.p" : {
+        "triplex_load" : {
+            "property" : ["base_power_{}"],
+            "prefix" : "ld_"
+        }
     }
 }
 
@@ -726,6 +732,9 @@ def _publish_to_fncs_bus(simulation_id, goss_message, command_filter):
                     elif cim_attribute == "PowerElectronicsConnection.q":
                         for y in object_phases:
                             fncs_input_message["{}".format(simulation_id)][object_name_prefix + object_name][object_property_list[0]] = float(x.get("value"))
+                    elif cim_attribute == "EnergyConsumer.p":
+                        for y in ["1","2"]:
+                            fncs_input_messag["{}".format(simulation_id)][object_name_prefix + object_name][object_property_list[0].format(y)] = float(x.get("value"))/2.0
                     else:
                         _send_simulation_status("RUNNING", "Attribute, {}, is not a supported attribute in the simulator at this current time. ignoring difference.", "WARN")
     
@@ -1094,6 +1103,7 @@ def _create_cim_object_map(map_file=None):
                 synchronousMachines = x.get("synchronousmachines", [])
                 breakers = x.get("breakers", [])
                 reclosers = x.get("reclosers", [])
+                energy_consumers = x.get("energyconsumers", [])
                 #TODO: add more object types to handle
                 for y in measurements:
                     measurement_type = y.get("measurementType")
@@ -1305,6 +1315,14 @@ def _create_cim_object_map(map_file=None):
                         "total_phases" : y.get("phases"),
                         "type" : "recloser",
                         "prefix" : "sw_"
+                    }
+                for y in energy_consumers:
+                    object_mrid_to_name[y.get("mRID")] = {
+                        "name" : y.get("name"),
+                        "phases" : y.get("phases"),
+                        "total_phases" : y.get("phases"),
+                        "type" : "triplex_load",
+                        "prefix" : "ld_"
                     }
         except Exception as e:
             _send_simulation_status('STARTED', "The measurement map file, {}, couldn't be translated.\nError:{}".format(map_file, e), 'ERROR')


### PR DESCRIPTION
# Description

This PR enables applications to change the EnergyConsumer.p attribute in the simulation.

Fixes # 1201

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

I ran a simulation with a modified sample app to change the EnergyConsumer.p and saw the load change when the message was sent by the sample app.