### PR TITLE
updated timeseries parse method to not use gson

### DIFF
--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesData.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesData.java
@@ -1,10 +1,15 @@
 package gov.pnnl.goss.gridappsd.dto;
 
+import java.io.IOException;
+
 //import gov.pnnl.goss.gridappsd.api.TimeseriesDataManager.ResultFormat;
 
 import java.io.Serializable;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
@@ -58,8 +63,17 @@ public class RequestTimeseriesData implements Serializable {
 	}
 	
 	public static RequestTimeseriesData parse(String jsonString){
-		Gson  gson = new Gson();
-		RequestTimeseriesData obj = gson.fromJson(jsonString, RequestTimeseriesData.class);
+		ObjectMapper objectMapper = new ObjectMapper();
+		RequestTimeseriesData obj = null;
+		try {
+			obj = objectMapper.readValue(jsonString, RequestTimeseriesData.class);
+		} catch (JsonParseException e) {
+			e.printStackTrace();
+		} catch (JsonMappingException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 		if(obj.queryMeasurement.equals("simulation"))
 			if(obj.queryFilter==null || !obj.queryFilter.containsKey("simulation_id"))
 				throw new JsonSyntaxException("Expected filter simulation_id not found.");


### PR DESCRIPTION
@ericstephan I changed Timeseries request to read timestamp correctly.
I am not getting the error now but data is coming out as empty. Please test and merge this pull request and then let me know if you get the data or something needs to be changed on proven/influx side.
