### PR TITLE
no player file if schedule_name not passed in request

### DIFF
--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDAllConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDAllConfigurationHandler.java
@@ -291,8 +291,10 @@ public class GLDAllConfigurationHandler extends BaseConfigurationHandler impleme
 		}
 		
 		//Generate zip load profile player file
-		GLDZiploadScheduleConfigurationHandler ziploadScheduleConfigurationHandler = new GLDZiploadScheduleConfigurationHandler(logManager, dataManager);
-		ziploadScheduleConfigurationHandler.generateConfig(parameters, null, processId, username);
+		if(scheduleName!=null && scheduleName.trim().length()>0) {
+			GLDZiploadScheduleConfigurationHandler ziploadScheduleConfigurationHandler = new GLDZiploadScheduleConfigurationHandler(logManager, dataManager);
+			ziploadScheduleConfigurationHandler.generateConfig(parameters, null, processId, username);
+		}
 		
 		//Generate startup file
 		File startupFile = new File(tempDataPath+File.separator+STARTUP_FILENAME);

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDZiploadScheduleConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDZiploadScheduleConfigurationHandler.java
@@ -164,7 +164,7 @@ public class GLDZiploadScheduleConfigurationHandler extends
 		String tempDataPath = dir.getAbsolutePath();
 		
 		String simulationID = GridAppsDConstants.getStringProperty(parameters, SIMULATIONID, null);
-		String loadprofile = GridAppsDConstants.getStringProperty(parameters, SCHEDULENAME, "loadprofile");
+		String loadprofile = GridAppsDConstants.getStringProperty(parameters, SCHEDULENAME, "ieeezipload");
 		int simId = -1;
 		if(simulationID==null || simulationID.trim().length()==0){
 			logError("No "+SIMULATIONID+" parameter provided", processId, username, logManager);


### PR DESCRIPTION
Platform should not generate player file if schedule_name key is not provided in simulation request..

How to test:;
1. Run a simulation without schedule name in request --> no player file in simulation folder
2. Run a simulation with ieeezipload schedule name (default) in request. --> ieeezipload player file in simulation folder