### PR TITLE
SoC measurement support

### DIFF
--- a/gov.pnnl.goss.gridappsd/bnd.bnd
+++ b/gov.pnnl.goss.gridappsd/bnd.bnd
@@ -29,7 +29,7 @@
 	osgi.enroute.base.api,\
 	org.mockito.mockito-all,\
 	httpcore,\
-	blazegraph.cim2glm;version=19.1.0,\
+	blazegraph.cim2glm;version=19.1.1,\
 	httpclient,\
 	com.bigdata.rdf,\
     proven-client;version=0.2.3,\

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDSimulationOutputConfigurationHandler.java
@@ -396,8 +396,11 @@ public class GLDSimulationOutputConfigurationHandler extends BaseConfigurationHa
 			} else if (measurementType.equals("A")) {
 				objectName = conductingEquipmentName;
 				propertyName = "measured_current_" + phases;
+			} else if (measurementType.equals("SoC")) {
+				objectName = conductingEquipmentName;
+				propertyName = "state_of_charge";
 			} else {
-				throw new JsonParseException(String.format("CimMeasurementsToGldPubs::parseMeasurement: The value of measurementType is not a valid type.\nValid types for PowerElectronicsConnection are VA, A, and PNV.\nmeasurementType = %s.",measurementType));
+				throw new JsonParseException(String.format("CimMeasurementsToGldPubs::parseMeasurement: The value of measurementType is not a valid type.\nValid types for PowerElectronicsConnection are VA, A, PNV, and SoC.\nmeasurementType = %s.",measurementType));
 			}
 		} else if (conductingEquipmentType.contains("SynchronousMachine")) {
 			if(measurementType.equals("VA")) {

--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -912,7 +912,7 @@ def _get_fncs_bus_messages(simulation_id, measurement_filter):
                                             measurement["value"] = int(val_str)
                                     elif conducting_equipment_type in ["ACLineSegment","EnergyConsumer","PowerElectronicsConnection","SynchronousMachine"]:
                                         if property_name == "state_of_charge":
-                                            measurement["value"] = float(val)*100.0
+                                            measurement["value"] = float(val_str)*100.0
                                         else:
                                             val = complex(val_str)
                                             (mag,ang_rad) = cmath.polar(val)

--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -908,11 +908,14 @@ def _get_fncs_bus_messages(simulation_id, measurement_filter):
                                         else:
                                             measurement["value"] = int(val_str)
                                     elif conducting_equipment_type in ["ACLineSegment","EnergyConsumer","PowerElectronicsConnection","SynchronousMachine"]:
-                                        val = complex(val_str)
-                                        (mag,ang_rad) = cmath.polar(val)
-                                        ang_deg = math.degrees(ang_rad)
-                                        measurement["magnitude"] = mag
-                                        measurement["angle"] = ang_deg
+                                        if property_name == "state_of_charge":
+                                            measurement["value"] = float(val)*100.0
+                                        else:
+                                            val = complex(val_str)
+                                            (mag,ang_rad) = cmath.polar(val)
+                                            ang_deg = math.degrees(ang_rad)
+                                            measurement["magnitude"] = mag
+                                            measurement["angle"] = ang_deg
                                     elif conducting_equipment_type in ["LoadBreakSwitch", "Recloser", "Breaker"]:
                                         if property_name in ["power_in_"+phases,"voltage_"+phases,"current_in_"+phases]:
                                             val = complex(val_str)
@@ -1243,6 +1246,9 @@ def _create_cim_object_map(map_file=None):
                         elif measurement_type == "A":
                             object_name = conducting_equipment_name;
                             property_name = "measured_current_" + phases;
+                        elif measurement_type == "SoC":
+                            object_name = conducting_equipment_name;
+                            property_name = "state_of_charge"
                         else:
                             raise RuntimeError("_create_cim_object_map: The value of measurement_type is not a valid type.\nValid types for PowerElectronicsConnection are VA, A, and PNV.\nmeasurement_type = %s.".format(measurement_type))
                     elif "SynchronousMachine" in conducting_equipment_type:


### PR DESCRIPTION
# Description
Adds SoC measurement support in the simulation engine.

Fixes # (issue)
1347
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested with the thirteen node model. Confirmed SoC measurements were coming out of the bridge.
