### PR TITLE
Don't use hard-coded user for fncs_goss_bridge

### DIFF
--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessManagerImpl.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessManagerImpl.java
@@ -160,7 +160,7 @@ public class ProcessManagerImpl implements ProcessManager {
 			client.publish(GridAppsDConstants.topic_platformLog, logMessageObj);
 
 			if(newSimulationProcess==null)
-				newSimulationProcess = new ProcessNewSimulationRequest(this.logManager);
+				newSimulationProcess = new ProcessNewSimulationRequest(this.logManager, this.securityConfig);
 
 			logMessageObj.setTimestamp(new Date().getTime());
 			logMessageObj.setLogMessage("Starting "+this.getClass().getName());

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessNewSimulationRequest.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/process/ProcessNewSimulationRequest.java
@@ -78,17 +78,20 @@ import java.util.Properties;
 import com.google.gson.Gson;
 
 import pnnl.goss.core.DataResponse;
+import pnnl.goss.core.security.SecurityConfig;
 
 public class ProcessNewSimulationRequest {
 
 	public ProcessNewSimulationRequest() {
 	}
 
-	public ProcessNewSimulationRequest(LogManager logManager) {
+	public ProcessNewSimulationRequest(LogManager logManager, SecurityConfig securityConfig) {
 		this.logManager = logManager;
+		this.securityConfig = securityConfig;
 	}
 
 	private volatile LogManager logManager;
+	private volatile SecurityConfig securityConfig;
 
 	public void process(ConfigurationManager configurationManager,
 			SimulationManager simulationManager, String simulationId,
@@ -188,6 +191,8 @@ public class ProcessNewSimulationRequest {
 			simulationContext.put("simulationDir",simulationConfigDir);
 			simulationContext.put("simulationFile",tempDataPathDir.getAbsolutePath()+File.separator+"model_startup.glm");
 			simulationContext.put("logLevel", logManager.getLogLevel());
+			simulationContext.put("username", securityConfig.getManagerUser());
+			simulationContext.put("password", securityConfig.getManagerPassword());
 			try{
 				simulationContext.put("simulatorPath",serviceManager.getService(simRequest.getSimulation_config().getSimulator()).getExecution_path());
 			}catch(NullPointerException e){

--- a/services/fncsgossbridge.config
+++ b/services/fncsgossbridge.config
@@ -4,7 +4,7 @@
 	"creator": "PNNL",
 	"inputs": ["/topic/goss.gridappsd.fncs.input"],
 	"outputs": ["/topic/goss.gridappsd.fncs.output"],
-	"static_args": ["(simulationId)","tcp://127.0.0.1:(simulationPort)","(simulationDir)","'(request)'","(logLevel)"],
+	"static_args": ["(simulationId)","tcp://127.0.0.1:(simulationPort)","(simulationDir)","'(request)'","(logLevel)","(username)","(password)"],
 	"execution_path": "/gridappsd/services/fncsgossbridge/service/fncs_goss_bridge.py",
 	"type": "PYTHON",
 	"launch_on_startup": "false",

--- a/services/fncsgossbridge/service/fncs_goss_bridge.py
+++ b/services/fncsgossbridge/service/fncs_goss_bridge.py
@@ -999,7 +999,7 @@ def _done_with_time_step(current_time):
         _send_simulation_status('ERROR', message_str, 'ERROR')
 
 
-def _register_with_goss(sim_id,username,password,goss_server='localhost',
+def _register_with_goss(sim_id,user,passwd,goss_server='localhost',
                       stomp_port='61613', sim_duration=86400, sim_start=0):
     """Register with the GOSS server broker and return.
 
@@ -1039,9 +1039,8 @@ def _register_with_goss(sim_id,username,password,goss_server='localhost',
     #goss_connection = stomp.Connection12([(goss_server, stomp_port)])
     #goss_connection.start()
     #goss_connection.connect(username,password, wait=True)
-    goss_connection = GridAPPSD(simulation_id, address=utils.get_gridappsd_address(),
-                                username=utils.get_gridappsd_user(), password=utils.get_gridappsd_pass())
-    #goss_connection.set_listener('GOSSListener', goss_listener_instance)
+    server = [goss_server, stomp_port]
+    goss_connection = GridAPPSD(simulation_id, address=server, username=user, password=passwd)
     #goss_connection.subscribe(input_from_goss_topic,1)
     #goss_connection.subscribe(simulation_input_topic + "{}".format(simulation_id),2)
     goss_connection.subscribe(input_from_goss_topic, goss_listener_instance)
@@ -1411,10 +1410,10 @@ def _keep_alive(is_realtime, archive_db_file, archive_file, only_archive):
 
 
 def _main(simulation_id, simulation_broker_location='tcp://localhost:5570', measurement_map_dir='', is_realtime=True,
-          sim_duration=86400, sim_start=0, archive_db_file=None, archive_file=None, only_archive=False):
+          sim_duration=86400, sim_start=0, archive_db_file=None, archive_file=None, only_archive=False, username='system', password='manger'):
     
     measurement_map_file=str(measurement_map_dir)+"model_dict.json"
-    _register_with_goss(simulation_id,'system','manager','127.0.0.1','61613', sim_duration, sim_start)
+    _register_with_goss(simulation_id,username,password,'127.0.0.1','61613', sim_duration, sim_start)
     _register_with_fncs_broker(simulation_broker_location)
     _create_cim_object_map(measurement_map_file)
     _keep_alive(is_realtime, archive_db_file, archive_file, only_archive)
@@ -1426,6 +1425,8 @@ def _get_opts():
     parser.add_argument("simulation_directory", help="The simulation files directory.")
     parser.add_argument("simulation_request", help="The simulation request.")
     parser.add_argument("logLevel", help="The log level at which platform was started")
+    parser.add_argument("username", help="The username to connect to the message bus.")
+    parser.add_argument("password", help="The password to connect to the message bus.")
     opts = parser.parse_args()
     return opts
 
@@ -1439,6 +1440,9 @@ if __name__ == "__main__":
     logfile = "/tmp/gridappsd_tmp/{simulation_id}/fncs_goss_bridge.log".format(simulation_id=simulation_id)
     logging.basicConfig(level=logging.INFO, filename=logfile)
 
+
+    username = opts.username
+    password = opts.password
     sim_broker_location = opts.broker_location
     sim_dir = opts.simulation_directory
     sim_request = json.loads(opts.simulation_request.replace("\'",""))
@@ -1462,4 +1466,4 @@ if __name__ == "__main__":
     _log.debug("Archive settings:\n\tarchive_db_file: {}\n\tarchive_file: {}\n\tonly_archive: {}".format(
         archive_db_file, archive_file, only_archive))
     _main(simulation_id, sim_broker_location, sim_dir, run_realtime, sim_duration, sim_start_str,
-          archive_db_file, archive_file, only_archive)
+          archive_db_file, archive_file, only_archive, username, password)


### PR DESCRIPTION
Changes to how fncsgossbridge is called so that it passes in the system user when the service is started

# Description

Instead of using a hardcoded username and password for the fncs_goss_bridge connection pass in the system credentials when starting the service.  In order to test it, change the system user's password in both pnnl.goss.core.security.userfile.cfg and pnnl.goss.security.cfg

