### PR TITLE
Stomp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG TIMESTAMP
 RUN cd ${TEMP_DIR} \
   && git clone https://github.com/GRIDAPPSD/gridappsd-python -b develop \
   && cd gridappsd-python \
-  && pip3 install . \
+  && pip3 install -r requirements.txt \
   && rm -rf /root/.cache/pip/wheels
 
 # Get the gridappsd-sensor-simulator from the proper repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN cd ${TEMP_DIR} \
   && git clone https://github.com/GRIDAPPSD/gridappsd-python -b develop \
   && cd gridappsd-python \
   && pip3 install -r requirements.txt \
+  && pip3 install . \
   && rm -rf /root/.cache/pip/wheels
 
 # Get the gridappsd-sensor-simulator from the proper repository


### PR DESCRIPTION
Install the gridappsd-python requirements.txt file first to install the specified version of stomp.
