### PR TITLE
removing simulation id from ochre house destination endpoint naming scheme in the helics bridge.

### DIFF
--- a/services/helicsgossbridge/service/helics_goss_bridge.py
+++ b/services/helicsgossbridge/service/helics_goss_bridge.py
@@ -862,7 +862,7 @@ class HelicsGossBridge(object):
                                 val = x.get("value")
                                 house_id = x.get("object")
                                 default_destination = helics.helicsEndpointGetDefaultDestination(helics_input_endpoint)
-                                ochre_destination = f"{self._simulation_id}/{house_id}/command_input"
+                                ochre_destination = f"{house_id}/command_input"
                                 helics.helicsEndpointSetDefaultDestination(helics_input_endpoint, ochre_destination)
                                 log.info(f"Sending the following message to {ochre_destination}. {val}")
                                 self._gad_connection.send_simulation_status("RUNNING", f"Sending the following message to {ochre_destination}. {val}","INFO")


### PR DESCRIPTION
due to the fact that right now when ochre is run in the platform it doesn't have access to the simulation id I'm
removing it from the endpoint destination name in the helics goss bridge.
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
