### PR TITLE
Time series filter

### DIFF
--- a/gov.pnnl.goss.gridappsd/conf/pnnl.goss.gridappsd.cfg
+++ b/gov.pnnl.goss.gridappsd/conf/pnnl.goss.gridappsd.cfg
@@ -28,5 +28,11 @@ proven.write.path = http://proven:8080/hybrid/rest/v1/repository/addBulkTimeSeri
 # docker-compose default network.
 proven.query.path = http://proven:8080/hybrid/rest/v1/repository/provenMessage
 
+# Uses docker composed proven host here.  Note this is not the
+# external address, but from inside one of the containers on the
+# docker-compose default network.
+proven.advanced_query.path = http://proven:8080/hybrid/rest/v1/repository/getAdvancedTsQuery
+
+
 # Power grid model MRID for deployed Field Bus
 field.model.mrid = _49AD8E07-3BF9-A4E2-CB8F-C3722F837B62

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDAllConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDAllConfigurationHandler.java
@@ -74,6 +74,7 @@ import gov.pnnl.goss.gridappsd.data.conversion.ProvenWeatherToGridlabdWeatherCon
 import gov.pnnl.goss.gridappsd.data.handlers.BlazegraphQueryHandler;
 import gov.pnnl.goss.gridappsd.dto.LogMessage.ProcessStatus;
 import gov.pnnl.goss.gridappsd.dto.RequestTimeseriesData;
+import gov.pnnl.goss.gridappsd.dto.RequestTimeseriesDataBasic;
 import gov.pnnl.goss.gridappsd.utils.GridAppsDConstants;
 import pnnl.goss.core.Client;
 import pnnl.goss.core.DataResponse;
@@ -253,7 +254,7 @@ public class GLDAllConfigurationHandler extends BaseConfigurationHandler impleme
 		//If use climate, then generate gridlabd weather data file
 		try {
 			if(useClimate){
-				RequestTimeseriesData weatherRequest = new RequestTimeseriesData();
+				RequestTimeseriesDataBasic weatherRequest = new RequestTimeseriesDataBasic();
 				weatherRequest.setQueryMeasurement("weather");
 				weatherRequest.setResponseFormat(ProvenWeatherToGridlabdWeatherConverter.OUTPUT_FORMAT);
 				Map<String, Object> queryFilter = new HashMap<String, Object>();

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDZiploadScheduleConfigurationHandler.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/configuration/GLDZiploadScheduleConfigurationHandler.java
@@ -49,6 +49,7 @@ import gov.pnnl.goss.gridappsd.dto.LogMessage;
 import gov.pnnl.goss.gridappsd.dto.LogMessage.LogLevel;
 import gov.pnnl.goss.gridappsd.dto.LogMessage.ProcessStatus;
 import gov.pnnl.goss.gridappsd.dto.RequestTimeseriesData;
+import gov.pnnl.goss.gridappsd.dto.RequestTimeseriesDataBasic;
 import gov.pnnl.goss.gridappsd.utils.GridAppsDConstants;
 
 import java.io.File;
@@ -164,7 +165,7 @@ public class GLDZiploadScheduleConfigurationHandler extends
 			logManager.error(ProcessStatus.ERROR, simulationID,"Simulation ID not a valid  "+simulationID+", defaulting to "+simId);
 		}
 				
-		RequestTimeseriesData request = new RequestTimeseriesData();
+		RequestTimeseriesDataBasic request = new RequestTimeseriesDataBasic();
 		request.setQueryMeasurement(loadprofile);
 		request.setResponseFormat(ProvenLoadScheduleToGridlabdLoadScheduleConverter.OUTPUT_FORMAT);
 		Map<String, Object> queryFilter = new HashMap<String, Object>();

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/data/ProvenTimeSeriesDataManagerImpl.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/data/ProvenTimeSeriesDataManagerImpl.java
@@ -25,6 +25,8 @@ import gov.pnnl.goss.gridappsd.api.TimeseriesDataManager;
 import gov.pnnl.goss.gridappsd.data.conversion.DataFormatConverter;
 import gov.pnnl.goss.gridappsd.dto.LogMessage.ProcessStatus;
 import gov.pnnl.goss.gridappsd.dto.RequestTimeseriesData;
+import gov.pnnl.goss.gridappsd.dto.RequestTimeseriesDataAdvanced;
+import gov.pnnl.goss.gridappsd.dto.RequestTimeseriesDataBasic;
 import gov.pnnl.goss.gridappsd.dto.SimulationContext;
 import gov.pnnl.goss.gridappsd.dto.TimeSeriesEntryResult;
 import gov.pnnl.goss.gridappsd.utils.GridAppsDConstants;
@@ -106,7 +108,20 @@ public class ProvenTimeSeriesDataManagerImpl implements TimeseriesDataManager, D
 			return query((RequestTimeseriesData)requestContent);
 		}
 		else if(requestContent instanceof String){
-			RequestTimeseriesData timeSeriesRequest = RequestTimeseriesData.parse((String)requestContent);
+			//First try to parse the query as the new format, if that fails try the old
+			RequestTimeseriesData timeSeriesRequest;
+			try{
+				timeSeriesRequest = RequestTimeseriesDataAdvanced.parse((String)requestContent);
+			}catch (Exception e) {
+				// TODO: handle exception
+				try{
+					timeSeriesRequest = RequestTimeseriesDataBasic.parse((String)requestContent);
+				}catch (Exception e2) {
+					throw new Exception("Failed to parse time series data request");
+				}
+			}
+			
+			
 			return query(timeSeriesRequest);
 		}
 		

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/data/ProvenTimeSeriesDataManagerImpl.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/data/ProvenTimeSeriesDataManagerImpl.java
@@ -75,6 +75,7 @@ public class ProvenTimeSeriesDataManagerImpl implements TimeseriesDataManager, D
 	Gson  gson = new Gson();
 	String provenUri = null;
     String provenQueryUri = null;
+    String provenAdvancedQueryUri = null;
     String provenWriteUri = null;
 
 	ProvenProducer provenQueryProducer = new ProvenProducer();
@@ -92,6 +93,7 @@ public class ProvenTimeSeriesDataManagerImpl implements TimeseriesDataManager, D
 		provenUri = configManager.getConfigurationProperty(GridAppsDConstants.PROVEN_PATH);
 		provenWriteUri = configManager.getConfigurationProperty(GridAppsDConstants.PROVEN_WRITE_PATH);
         provenQueryUri = configManager.getConfigurationProperty(GridAppsDConstants.PROVEN_QUERY_PATH);	
+        provenAdvancedQueryUri = configManager.getConfigurationProperty(GridAppsDConstants.PROVEN_ADVANCED_QUERY_PATH);	
         provenQueryProducer.restProducer(provenQueryUri, null, null);
         provenWriteProducer.restProducer(provenWriteUri, null, null);
         
@@ -131,7 +133,13 @@ public class ProvenTimeSeriesDataManagerImpl implements TimeseriesDataManager, D
 	@Override
 	public Serializable query(RequestTimeseriesData requestTimeseriesData) throws Exception {
 		
-		provenQueryProducer.restProducer(provenQueryUri, null, null);
+		if(requestTimeseriesData instanceof RequestTimeseriesDataAdvanced){
+		
+			provenQueryProducer.restProducer(provenAdvancedQueryUri, null, null);
+		} else {
+			provenQueryProducer.restProducer(provenQueryUri, null, null);
+
+		}
 		provenQueryProducer.setMessageInfo("GridAPPSD", "QUERY", this.getClass().getSimpleName(), keywords);
 		ProvenResponse response = provenQueryProducer.sendMessage(requestTimeseriesData.toString(), requestId);
 		TimeSeriesEntryResult result = TimeSeriesEntryResult.parse(response.data.toString());

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesData.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesData.java
@@ -1,8 +1,6 @@
 package gov.pnnl.goss.gridappsd.dto;
 
 
-//import gov.pnnl.goss.gridappsd.api.TimeseriesDataManager.ResultFormat;
-
 import java.io.Serializable;
 
 import com.google.gson.Gson;
@@ -12,7 +10,6 @@ public abstract class RequestTimeseriesData implements Serializable {
 	private static final long serialVersionUID = -820277813503252519L;
 	
 	String queryMeasurement;
-	//ResultFormat responseFormat = ResultFormat.JSON;
 	String responseFormat ="JSON";
 	private String queryType = "time-series";
 	int simulationYear;

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesData.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesData.java
@@ -5,7 +5,11 @@ import java.io.IOException;
 //import gov.pnnl.goss.gridappsd.api.TimeseriesDataManager.ResultFormat;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+
+import org.apache.activemq.console.filter.QueryFilter;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -18,8 +22,12 @@ public class RequestTimeseriesData implements Serializable {
 	private static final long serialVersionUID = -820277813503252519L;
 	
 	String queryMeasurement;
-	Map<String,Object> queryFilter;
+	//Map<String,Object> queryFilter;
+	List<QueryFilter> queryFilter = new ArrayList<QueryFilter>();
+
 	//ResultFormat responseFormat = ResultFormat.JSON;
+	List<String> selectCriteria = new ArrayList<String>();
+	int last = 1;
 	String responseFormat ="JSON";
 	private String queryType = "time-series";
 	int simulationYear;
@@ -33,11 +41,11 @@ public class RequestTimeseriesData implements Serializable {
 		this.queryMeasurement = queryMeasurement;
 	}
 
-	public Map<String, Object> getQueryFilter() {
+	public List<QueryFilter> getQueryFilter() {
 		return queryFilter;
 	}
 
-	public void setQueryFilter(Map<String, Object> queryFilter) {
+	public void setQueryFilter(List<QueryFilter> queryFilter) {
 		this.queryFilter = queryFilter;
 	}
 
@@ -83,10 +91,61 @@ public class RequestTimeseriesData implements Serializable {
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		if(obj.queryMeasurement.equals("simulation"))
-			if(obj.queryFilter==null || !obj.queryFilter.containsKey("simulation_id"))
-				throw new JsonSyntaxException("Expected filter simulation_id not found.");
-		return obj;
+		if(obj.queryMeasurement.equals("simulation")){
+			//if(obj.queryFilter==null || !obj.queryFilter.containsKey("simulation_id"))
+			//	throw new JsonSyntaxException("Expected filter simulation_id not found.");
+		//TODO iterate through and look for key = simulation_id
+		}
+			return obj;
 	}
 	
+	
+	
+
+	private class QueryFilter {
+		String key;
+		String eq;
+		String ge;
+		String le;
+		String gt;
+		String lt;
+		public String getKey() {
+			return key;
+		}
+		public void setKey(String key) {
+			this.key = key;
+		}
+		public String getEq() {
+			return eq;
+		}
+		public void setEq(String eq) {
+			this.eq = eq;
+		}
+		public String getGe() {
+			return ge;
+		}
+		public void setGe(String ge) {
+			this.ge = ge;
+		}
+		public String getLe() {
+			return le;
+		}
+		public void setLe(String le) {
+			this.le = le;
+		}
+		public String getGt() {
+			return gt;
+		}
+		public void setGt(String gt) {
+			this.gt = gt;
+		}
+		public String getLt() {
+			return lt;
+		}
+		public void setLt(String lt) {
+			this.lt = lt;
+		}
+		
+		
+	}	
 }

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesData.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesData.java
@@ -1,33 +1,18 @@
 package gov.pnnl.goss.gridappsd.dto;
 
-import java.io.IOException;
 
 //import gov.pnnl.goss.gridappsd.api.TimeseriesDataManager.ResultFormat;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
-import org.apache.activemq.console.filter.QueryFilter;
-
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
 
-public class RequestTimeseriesData implements Serializable {
+public abstract class RequestTimeseriesData implements Serializable {
 	
 	private static final long serialVersionUID = -820277813503252519L;
 	
 	String queryMeasurement;
-	//Map<String,Object> queryFilter;
-	List<QueryFilter> queryFilter = new ArrayList<QueryFilter>();
-
 	//ResultFormat responseFormat = ResultFormat.JSON;
-	List<String> selectCriteria = new ArrayList<String>();
-	int last = 1;
 	String responseFormat ="JSON";
 	private String queryType = "time-series";
 	int simulationYear;
@@ -41,13 +26,6 @@ public class RequestTimeseriesData implements Serializable {
 		this.queryMeasurement = queryMeasurement;
 	}
 
-	public List<QueryFilter> getQueryFilter() {
-		return queryFilter;
-	}
-
-	public void setQueryFilter(List<QueryFilter> queryFilter) {
-		this.queryFilter = queryFilter;
-	}
 
 	public String getResponseFormat() {
 		return responseFormat;
@@ -72,6 +50,14 @@ public class RequestTimeseriesData implements Serializable {
 	public void setOriginalFormat(String originalFormat) {
 		this.originalFormat = originalFormat;
 	}
+	
+	public String getQueryType() {
+		return queryType;
+	}
+
+	public void setQueryType(String queryType) {
+		this.queryType = queryType;
+	}
 
 	@Override
 	public String toString() {
@@ -79,73 +65,6 @@ public class RequestTimeseriesData implements Serializable {
 		return gson.toJson(this);
 	}
 	
-	public static RequestTimeseriesData parse(String jsonString){
-		ObjectMapper objectMapper = new ObjectMapper();
-		RequestTimeseriesData obj = null;
-		try {
-			obj = objectMapper.readValue(jsonString, RequestTimeseriesData.class);
-		} catch (JsonParseException e) {
-			e.printStackTrace();
-		} catch (JsonMappingException e) {
-			e.printStackTrace();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		if(obj.queryMeasurement.equals("simulation")){
-			//if(obj.queryFilter==null || !obj.queryFilter.containsKey("simulation_id"))
-			//	throw new JsonSyntaxException("Expected filter simulation_id not found.");
-		//TODO iterate through and look for key = simulation_id
-		}
-			return obj;
-	}
 	
 	
-	
-
-	private class QueryFilter {
-		String key;
-		String eq;
-		String ge;
-		String le;
-		String gt;
-		String lt;
-		public String getKey() {
-			return key;
-		}
-		public void setKey(String key) {
-			this.key = key;
-		}
-		public String getEq() {
-			return eq;
-		}
-		public void setEq(String eq) {
-			this.eq = eq;
-		}
-		public String getGe() {
-			return ge;
-		}
-		public void setGe(String ge) {
-			this.ge = ge;
-		}
-		public String getLe() {
-			return le;
-		}
-		public void setLe(String le) {
-			this.le = le;
-		}
-		public String getGt() {
-			return gt;
-		}
-		public void setGt(String gt) {
-			this.gt = gt;
-		}
-		public String getLt() {
-			return lt;
-		}
-		public void setLt(String lt) {
-			this.lt = lt;
-		}
-		
-		
-	}	
 }

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesDataAdvanced.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesDataAdvanced.java
@@ -1,0 +1,153 @@
+package gov.pnnl.goss.gridappsd.dto;
+
+import java.io.IOException;
+
+//import gov.pnnl.goss.gridappsd.api.TimeseriesDataManager.ResultFormat;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.activemq.console.filter.QueryFilter;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+
+public class RequestTimeseriesDataAdvanced extends RequestTimeseriesData {
+	
+	private static final long serialVersionUID = -820277813503252519L;
+	
+	String queryMeasurement;
+//	Map<String,Object> queryFilter;
+	List<Filter> queryFilter = new ArrayList<Filter>();
+
+	//ResultFormat responseFormat = ResultFormat.JSON;
+	List<String> selectCriteria = new ArrayList<String>();
+	int last = -1;
+	int first = -1;
+
+	
+	public String getQueryMeasurement() {
+		return queryMeasurement;
+	}
+
+	public void setQueryMeasurement(String queryMeasurement) {
+		this.queryMeasurement = queryMeasurement;
+	}
+
+	
+
+
+	public List<Filter> getQueryFilter() {
+		return queryFilter;
+	}
+
+	public void setQueryFilter(List<Filter> advancedQueryFilter) {
+		this.queryFilter = advancedQueryFilter;
+	}
+
+	public List<String> getSelectCriteria() {
+		return selectCriteria;
+	}
+
+	public void setSelectCriteria(List<String> selectCriteria) {
+		this.selectCriteria = selectCriteria;
+	}
+
+	public int getLast() {
+		return last;
+	}
+
+	public void setLast(int last) {
+		this.last = last;
+	}
+
+	public int getFirst() {
+		return first;
+	}
+
+	public void setFirst(int first) {
+		this.first = first;
+	}
+
+
+	@Override
+	public String toString() {
+		Gson  gson = new Gson();
+		return gson.toJson(this);
+	}
+	
+	public static RequestTimeseriesDataAdvanced parse(String jsonString){
+		ObjectMapper objectMapper = new ObjectMapper();
+		RequestTimeseriesDataAdvanced obj = null;
+		try {
+			obj = objectMapper.readValue(jsonString, RequestTimeseriesDataAdvanced.class);
+		} catch (JsonParseException e) {
+			e.printStackTrace();
+		} catch (JsonMappingException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		if(obj.queryMeasurement.equals("simulation")){
+			//if(obj.queryFilter==null || !obj.queryFilter.containsKey("simulation_id"))
+			//	throw new JsonSyntaxException("Expected filter simulation_id not found.");
+		//TODO iterate through and look for key = simulation_id
+		}
+			return obj;
+	}
+	
+	
+	
+
+	private class Filter {
+		String key;
+		String eq;
+		String ge;
+		String le;
+		String gt;
+		String lt;
+		public String getKey() {
+			return key;
+		}
+		public void setKey(String key) {
+			this.key = key;
+		}
+		public String getEq() {
+			return eq;
+		}
+		public void setEq(String eq) {
+			this.eq = eq;
+		}
+		public String getGe() {
+			return ge;
+		}
+		public void setGe(String ge) {
+			this.ge = ge;
+		}
+		public String getLe() {
+			return le;
+		}
+		public void setLe(String le) {
+			this.le = le;
+		}
+		public String getGt() {
+			return gt;
+		}
+		public void setGt(String gt) {
+			this.gt = gt;
+		}
+		public String getLt() {
+			return lt;
+		}
+		public void setLt(String lt) {
+			this.lt = lt;
+		}
+		
+		
+	}	
+}

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesDataAdvanced.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesDataAdvanced.java
@@ -2,14 +2,9 @@ package gov.pnnl.goss.gridappsd.dto;
 
 import java.io.IOException;
 
-//import gov.pnnl.goss.gridappsd.api.TimeseriesDataManager.ResultFormat;
-
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
-import org.apache.activemq.console.filter.QueryFilter;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -19,58 +14,45 @@ import com.google.gson.JsonSyntaxException;
 
 public class RequestTimeseriesDataAdvanced extends RequestTimeseriesData {
 	
-	private static final long serialVersionUID = -820277813503252519L;
+	private static final long serialVersionUID = -820277813503252512L;
 	
-	String queryMeasurement;
-//	Map<String,Object> queryFilter;
-	List<Filter> queryFilter = new ArrayList<Filter>();
-
-	//ResultFormat responseFormat = ResultFormat.JSON;
+	List<Object> queryFilter = new ArrayList<Object>();
+ 
 	List<String> selectCriteria = new ArrayList<String>();
-	int last = -1;
-	int first = -1;
+	Integer last;
+	Integer first;
 
-	
-	public String getQueryMeasurement() {
-		return queryMeasurement;
-	}
-
-	public void setQueryMeasurement(String queryMeasurement) {
-		this.queryMeasurement = queryMeasurement;
-	}
-
-	
-
-
-	public List<Filter> getQueryFilter() {
+	public List<Object> getQueryFilter() {
 		return queryFilter;
 	}
 
-	public void setQueryFilter(List<Filter> advancedQueryFilter) {
+	public void setQueryFilter(List<Object> advancedQueryFilter) {
 		this.queryFilter = advancedQueryFilter;
 	}
+	
+	
 
 	public List<String> getSelectCriteria() {
 		return selectCriteria;
 	}
-
 	public void setSelectCriteria(List<String> selectCriteria) {
 		this.selectCriteria = selectCriteria;
 	}
+	
 
-	public int getLast() {
+	public Integer getLast() {
 		return last;
 	}
 
-	public void setLast(int last) {
+	public void setLast(Integer last) {
 		this.last = last;
 	}
 
-	public int getFirst() {
+	public Integer getFirst() {
 		return first;
 	}
 
-	public void setFirst(int first) {
+	public void setFirst(Integer first) {
 		this.first = first;
 	}
 
@@ -84,70 +66,30 @@ public class RequestTimeseriesDataAdvanced extends RequestTimeseriesData {
 	public static RequestTimeseriesDataAdvanced parse(String jsonString){
 		ObjectMapper objectMapper = new ObjectMapper();
 		RequestTimeseriesDataAdvanced obj = null;
+		String error = "";
 		try {
 			obj = objectMapper.readValue(jsonString, RequestTimeseriesDataAdvanced.class);
 		} catch (JsonParseException e) {
 			e.printStackTrace();
+			error = e.getMessage();
 		} catch (JsonMappingException e) {
 			e.printStackTrace();
+			error = e.getMessage();
 		} catch (IOException e) {
 			e.printStackTrace();
+			error = e.getMessage();
 		}
-		if(obj.queryMeasurement.equals("simulation")){
+		if(obj==null){
+			throw new JsonSyntaxException("Request time series data request could not be parsed: "+error);
+		}
+		
+//		if(obj!=null && obj.queryMeasurement.equals("simulation")){
 			//if(obj.queryFilter==null || !obj.queryFilter.containsKey("simulation_id"))
 			//	throw new JsonSyntaxException("Expected filter simulation_id not found.");
 		//TODO iterate through and look for key = simulation_id
-		}
-			return obj;
+		return obj;
 	}
 	
 	
 	
-
-	private class Filter {
-		String key;
-		String eq;
-		String ge;
-		String le;
-		String gt;
-		String lt;
-		public String getKey() {
-			return key;
-		}
-		public void setKey(String key) {
-			this.key = key;
-		}
-		public String getEq() {
-			return eq;
-		}
-		public void setEq(String eq) {
-			this.eq = eq;
-		}
-		public String getGe() {
-			return ge;
-		}
-		public void setGe(String ge) {
-			this.ge = ge;
-		}
-		public String getLe() {
-			return le;
-		}
-		public void setLe(String le) {
-			this.le = le;
-		}
-		public String getGt() {
-			return gt;
-		}
-		public void setGt(String gt) {
-			this.gt = gt;
-		}
-		public String getLt() {
-			return lt;
-		}
-		public void setLt(String lt) {
-			this.lt = lt;
-		}
-		
-		
-	}	
 }

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesDataBasic.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesDataBasic.java
@@ -1,0 +1,64 @@
+package gov.pnnl.goss.gridappsd.dto;
+
+import java.io.IOException;
+
+//import gov.pnnl.goss.gridappsd.api.TimeseriesDataManager.ResultFormat;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+
+public class RequestTimeseriesDataBasic extends RequestTimeseriesData {
+	
+	private static final long serialVersionUID = -820277813503252519L;
+	
+	String queryMeasurement;
+	Map<String,Object> queryFilter;
+	
+	public String getQueryMeasurement() {
+		return queryMeasurement;
+	}
+
+	public void setQueryMeasurement(String queryMeasurement) {
+		this.queryMeasurement = queryMeasurement;
+	}
+
+	public Map<String, Object> getQueryFilter() {
+		return queryFilter;
+	}
+
+	public void setQueryFilter(Map<String, Object> queryFilter) {
+		this.queryFilter = queryFilter;
+	}
+
+
+	@Override
+	public String toString() {
+		Gson  gson = new Gson();
+		return gson.toJson(this);
+	}
+	
+	public static RequestTimeseriesDataBasic parse(String jsonString){
+		ObjectMapper objectMapper = new ObjectMapper();
+		RequestTimeseriesDataBasic obj = null;
+		try {
+			obj = objectMapper.readValue(jsonString, RequestTimeseriesDataBasic.class);
+		} catch (JsonParseException e) {
+			e.printStackTrace();
+		} catch (JsonMappingException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		if(obj.queryMeasurement.equals("simulation"))
+			if(obj.queryFilter==null || !obj.queryFilter.containsKey("simulation_id"))
+				throw new JsonSyntaxException("Expected filter simulation_id not found.");
+		return obj;
+	}
+	
+}

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesDataBasic.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/dto/RequestTimeseriesDataBasic.java
@@ -15,18 +15,9 @@ import com.google.gson.JsonSyntaxException;
 
 public class RequestTimeseriesDataBasic extends RequestTimeseriesData {
 	
-	private static final long serialVersionUID = -820277813503252519L;
+	private static final long serialVersionUID = -820277813503252513L;
 	
-	String queryMeasurement;
 	Map<String,Object> queryFilter;
-	
-	public String getQueryMeasurement() {
-		return queryMeasurement;
-	}
-
-	public void setQueryMeasurement(String queryMeasurement) {
-		this.queryMeasurement = queryMeasurement;
-	}
 
 	public Map<String, Object> getQueryFilter() {
 		return queryFilter;
@@ -46,18 +37,25 @@ public class RequestTimeseriesDataBasic extends RequestTimeseriesData {
 	public static RequestTimeseriesDataBasic parse(String jsonString){
 		ObjectMapper objectMapper = new ObjectMapper();
 		RequestTimeseriesDataBasic obj = null;
+		String error = "";
 		try {
 			obj = objectMapper.readValue(jsonString, RequestTimeseriesDataBasic.class);
 		} catch (JsonParseException e) {
 			e.printStackTrace();
+			error = e.getMessage();
 		} catch (JsonMappingException e) {
 			e.printStackTrace();
+			error = e.getMessage();
 		} catch (IOException e) {
 			e.printStackTrace();
+			error = e.getMessage();
 		}
-		if(obj.queryMeasurement.equals("simulation"))
-			if(obj.queryFilter==null || !obj.queryFilter.containsKey("simulation_id"))
-				throw new JsonSyntaxException("Expected filter simulation_id not found.");
+		if(obj==null){
+			throw new JsonSyntaxException("Request time series data request could not be parsed: "+error);
+		}
+//		if(obj!=null && obj.queryMeasurement.equals("simulation"))
+//			if(obj.queryFilter==null || !obj.queryFilter.containsKey("simulation_id"))
+//				throw new JsonSyntaxException("Expected filter simulation_id not found.");
 		return obj;
 	}
 	

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/testmanager/HistoricalComparison.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/testmanager/HistoricalComparison.java
@@ -17,6 +17,7 @@ import com.google.gson.JsonParser;
 
 import gov.pnnl.goss.gridappsd.api.DataManager;
 import gov.pnnl.goss.gridappsd.dto.RequestTimeseriesData;
+import gov.pnnl.goss.gridappsd.dto.RequestTimeseriesDataBasic;
 import gov.pnnl.goss.gridappsd.dto.TestConfig;
 import pnnl.goss.core.Client;
 
@@ -91,7 +92,7 @@ public class HistoricalComparison {
 		 queryFilter = new HashMap<String, Object>();
 		 queryFilter.put("simulation_id", simulationId);
 			
-		RequestTimeseriesData request = new RequestTimeseriesData();
+		 RequestTimeseriesDataBasic request = new RequestTimeseriesDataBasic();
 		request.setSimulationYear(0);
 		request.setQueryMeasurement("simulation");
 		request.setQueryFilter(queryFilter);

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/utils/GridAppsDConstants.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/utils/GridAppsDConstants.java
@@ -161,6 +161,7 @@ public class GridAppsDConstants {
 	public static final String PROVEN_PATH = "proven.path";
 	public static final String PROVEN_WRITE_PATH = "proven.write.path";
 	public static final String PROVEN_QUERY_PATH = "proven.query.path";
+	public static final String PROVEN_ADVANCED_QUERY_PATH = "proven.advanced_query.path";
 
 	public static final SimpleDateFormat SDF_SIMULATION_REQUEST = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
 	public static final SimpleDateFormat SDF_GLM_CLOCK = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");

--- a/gov.pnnl.goss.gridappsd/test/gov/pnnl/goss/gridappsd/TestManagerComponentTest.java
+++ b/gov.pnnl.goss.gridappsd/test/gov/pnnl/goss/gridappsd/TestManagerComponentTest.java
@@ -37,6 +37,7 @@ import gov.pnnl.goss.gridappsd.dto.LogMessage;
 import gov.pnnl.goss.gridappsd.dto.LogMessage.LogLevel;
 import gov.pnnl.goss.gridappsd.dto.LogMessage.ProcessStatus;
 import gov.pnnl.goss.gridappsd.dto.RequestTimeseriesData;
+import gov.pnnl.goss.gridappsd.dto.RequestTimeseriesDataBasic;
 import gov.pnnl.goss.gridappsd.dto.TestConfig;
 //import gov.pnnl.goss.gridappsd.dto.TestConfiguration;
 //import gov.pnnl.goss.gridappsd.dto.TestScript;
@@ -206,7 +207,7 @@ public class TestManagerComponentTest {
 
 		ProvenTimeSeriesDataManagerImpl provenTimeSeriesDataManager = new ProvenTimeSeriesDataManagerImpl();
 
-		RequestTimeseriesData request = new RequestTimeseriesData(); 
+		RequestTimeseriesDataBasic request = new RequestTimeseriesDataBasic(); 
 		HashMap<String,Object> queryFilter = new HashMap <String,Object>();
 		queryFilter.put("hasSimulationId", "145774843");
 		request.setQueryMeasurement("simulation");


### PR DESCRIPTION
# Description

Supports new query filter format for proven time series queries.  It will first try to parse the request using the new format and if that fails will try the original format  Example query may look like 

{
    "queryMeasurement": "weather",
    "queryFilter": [
        {
            "key": "simulation_id",
            "eq": "687235791"
        },
        {
            "key": "timestamp",
            "ge": 1248159974000000000
        },
        {
            "key": "timestamp",
            "le": 1248159984000000000
        }
    ],
    "responseFormat": "JSON"
}

