### PR TITLE
Adding optional automatic simulation pause after publish

### DIFF
--- a/services/helicsgossbridge/service/helics_goss_bridge.py
+++ b/services/helicsgossbridge/service/helics_goss_bridge.py
@@ -794,10 +794,6 @@ class HelicsGossBridge(object):
                         object_property_list = ((self._difference_attribute_map.get(x.get("attribute", ""),
                                                                                     {})).get(object_type,
                                                                                              {})).get("property")
-                        phase_in_property = ((self._difference_attribute_map.get(x.get("attribute", ""),
-                                                                                 {})).get(object_type,
-                                                                                          {})).get("phase_sensitive",
-                                                                                                   False)
                         if cim_attribute != "Ochre.command":
                             if object_name == None or object_phases == None or object_total_phases == None \
                                     or object_type == None or object_name_prefix == None or cim_attribute == None \


### PR DESCRIPTION
This adds the option to specify the helicsgossbridge to pause the simulation automatically after publishing measurements.

To test:
Add the key:value pair "pause_after_measurements": true to the "simulation_config" dictionary value in the simulation request. This should cause the simulation to enter the PAUSE state automatically after every time the helicsgossbridge  sends measurements. This should be only be utilized by the Simulation class in gridappsd-python for application testing purposes.
