### PR TITLE
fix: collectBundles clears stale bundles from launcher dir

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,13 +187,16 @@ task copyConfig(type: Copy) {
 // this as an upstream dependency guarantees the directory is empty before either
 // writer runs, on every collectBundles/dist invocation, with or without a prior
 // make clean.
-task cleanBundleDir {
+//
+// felixDeps are downloaded into a separate persistent cache
+// ($buildDir/felixDepsCache, see the collectBundles doFirst block below) and
+// copied into this directory on every run, so wiping this directory here does
+// not force a re-download of the ~98 Maven Central jars on a warm rebuild.
+task cleanBundleDir(type: Delete) {
     group = 'GridAPPS-D'
     description = 'Deletes the launcher bundle directory so collectBundles cannot leave stale, differently-versioned bundles behind on a no-clean rebuild'
 
-    doLast {
-        delete "$buildDir/launcher/bundle"
-    }
+    delete "$buildDir/launcher/bundle"
 }
 
 // Task to collect all bundle JARs
@@ -476,7 +479,16 @@ task collectBundles(type: Copy) {
         def destDir = file("$buildDir/launcher/bundle")
         destDir.mkdirs()
 
-        // Download Maven dependencies
+        // Downloaded jars live in a cache directory outside build/launcher/bundle,
+        // so cleanBundleDir (which wipes build/launcher/bundle on every
+        // collectBundles run to remove stale versioned GOSS-Core bundles, see
+        // above) does not also force these ~98 fixed-version Maven Central jars
+        // to re-download on every rebuild. The cache survives across `dist`
+        // invocations; only `clean` (which deletes the whole $buildDir) empties it.
+        def cacheDir = file("$buildDir/felixDepsCache")
+        cacheDir.mkdirs()
+
+        // Download Maven dependencies (cached), then copy into the bundle dir
         felixDeps.each { dep ->
             def parts = dep.split(':')
             def group = parts[0].replace('.', '/')
@@ -484,16 +496,20 @@ task collectBundles(type: Copy) {
             def version = parts[2]
             def jarName = "${artifact}-${version}.jar"
             def url = "https://repo1.maven.org/maven2/${group}/${artifact}/${version}/${jarName}"
-            def destFile = new File(destDir, jarName)
+            def cacheFile = new File(cacheDir, jarName)
 
-            if (!destFile.exists()) {
+            if (!cacheFile.exists()) {
                 println "Downloading ${jarName}..."
                 new URL(url).withInputStream { input ->
-                    destFile.withOutputStream { output ->
+                    cacheFile.withOutputStream { output ->
                         output << input
                     }
                 }
             }
+
+            def destFile = new File(destDir, jarName)
+            java.nio.file.Files.copy(cacheFile.toPath(), destFile.toPath(),
+                java.nio.file.StandardCopyOption.REPLACE_EXISTING)
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -178,6 +178,24 @@ task copyConfig(type: Copy) {
     }
 }
 
+// Task to delete the bundle directory before collectBundles repopulates it.
+// collectBundles places jars two ways: declarative Copy specs (from(...)) and
+// raw file I/O in a doFirst block (the felixDeps Maven downloads below). A plain
+// Copy task, or even a type: Sync task, only reconciles the declarative specs;
+// it cannot see the felixDeps jars and would either leave stale versions behind
+// (Copy) or delete jars that are not covered by any from() spec (Sync). Wiring
+// this as an upstream dependency guarantees the directory is empty before either
+// writer runs, on every collectBundles/dist invocation, with or without a prior
+// make clean.
+task cleanBundleDir {
+    group = 'GridAPPS-D'
+    description = 'Deletes the launcher bundle directory so collectBundles cannot leave stale, differently-versioned bundles behind on a no-clean rebuild'
+
+    doLast {
+        delete "$buildDir/launcher/bundle"
+    }
+}
+
 // Task to collect all bundle JARs
 task collectBundles(type: Copy) {
     group = 'GridAPPS-D'
@@ -190,6 +208,7 @@ task collectBundles(type: Copy) {
     dependsOn ':gridappsd-poi:shadowJar'
     dependsOn assembleLauncher
     dependsOn copyConfig
+    dependsOn cleanBundleDir
 
     into "$buildDir/launcher/bundle"
 


### PR DESCRIPTION
## What

`collectBundles` populated `build/launcher/bundle/` without ever deleting stale entries, so a `dist` run after a GOSS-Core version change (without a preceding `make clean`) left both the old and new versions of every `pnnl.goss.core.*` bundle side by side in the launcher. Shipping two versions of the same OSGi bundle symbolic name is a latent runtime hazard (ambiguous resolution), and it is silent at build time.

This adds a `cleanBundleDir` task (`type: Delete`) wired as a `collectBundles` dependency, so the bundle directory starts empty before either writer runs on every build, with or without a prior clean.

## Why the obvious one-line fix does not work

`collectBundles` populates the directory two ways: declarative `from(...)` copy specs AND a `doFirst` block that downloads the felixDeps Maven jars via raw file I/O. A `type: Copy` never deletes stale files; a `type: Sync` would delete the felixDeps jars entirely (they are outside any `from()` spec). Wiring a `dependsOn` delete ahead of the task is the approach that reconciles both writers.

## felixDeps download cache

Because the bundle directory is now wiped every run, the felixDeps download loop (guarded by `if (!file.exists())`) would re-download ~98 Maven Central jars on every local build. To avoid that, felixDeps now download into a persistent `$buildDir/felixDepsCache` (survives `cleanBundleDir`; only a full `clean` empties it) and are copied into the bundle directory unconditionally on each run. Downloads happen once; warm rebuilds reuse the cache.

## Verification

- Stale removal: a planted `pnnl.goss.core.core-api-9.9.9.jar` dummy is removed on the next no-clean `dist`; the final GOSS-Core set is exactly the correct single version (8 jars).
- No re-download on warm rebuild: a second back-to-back `dist` prints zero `Downloading ...` lines for the felixDeps set and completes in ~1s.
- felixDeps still present in the final dist (nimbus-jose-jwt, jakarta.el-api, felix.framework spot-checked); total bundle count unchanged at 111.
- `./gradlew build`: 240 tests, no regression from this change (scope is `build.gradle` only).

## Scope

`build.gradle` only. Two commits (the fix, then the felixDeps-cache follow-up); please do not squash. Does not touch the felixDeps integrity-verification gap (no checksum on the Maven fetch), which is tracked separately.

## Test plan

- [ ] `make clean && make dist` produces a single-version launcher.
- [ ] `make dist` twice with no clean between, across a version bump, leaves no stale duplicate bundles.
- [ ] Second consecutive `dist` does not re-download felixDeps.
