### PR TITLE
fix: add pnnl.goss.core.security-system bundle to bnd manifests so the ActiveMQ broker binds

### DIFF
--- a/gov.pnnl.goss.gridappsd/bnd.bnd
+++ b/gov.pnnl.goss.gridappsd/bnd.bnd
@@ -10,6 +10,7 @@
 	pnnl.goss.core.goss-core-server-registry;version=latest,\
 	pnnl.goss.core.security-propertyfile;version=latest,\
 	pnnl.goss.core.security-jwt;version=latest,\
+	pnnl.goss.core.security-system;version=latest,\
 	jakarta.jms:jakarta.jms-api;version='3.1.0',\
 	org.slf4j:slf4j-api;version='2.0.16',\
 	org.apache.activemq:activemq-osgi;version='6.2.0',\

--- a/gov.pnnl.goss.gridappsd/include.bndrun
+++ b/gov.pnnl.goss.gridappsd/include.bndrun
@@ -29,6 +29,7 @@ shared.runrequires: \
 	osgi.identity;filter:='(osgi.identity=pnnl.goss.core.goss-core-server-api)',\
 	osgi.identity;filter:='(osgi.identity=pnnl.goss.core.goss-core-security)',\
 	osgi.identity;filter:='(osgi.identity=pnnl.goss.core.security-propertyfile)',\
+	osgi.identity;filter:='(osgi.identity=pnnl.goss.core.security-system)',\
 	osgi.identity;filter:='(&(osgi.identity=org.apache.felix.gogo.runtime)(version>=1.1.0))',\
 	osgi.identity;filter:='(&(osgi.identity=org.apache.felix.gogo.shell)(version>=1.1.0))',\
 	osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.command)',\

--- a/gov.pnnl.goss.gridappsd/run.bnd.bndrun
+++ b/gov.pnnl.goss.gridappsd/run.bnd.bndrun
@@ -32,6 +32,7 @@
 	pnnl.goss.core.goss-core-server-api;version='[13.0.0,13.0.1)',\
 	pnnl.goss.core.security-propertyfile;version='[13.0.0,13.0.1)',\
 	pnnl.goss.core.security-jwt;version='[13.0.0,13.0.1)',\
+	pnnl.goss.core.security-system;version='[13.0.0,13.0.1)',\
 	com.google.gson;version='[2.11.0,2.12.0)',\
 	org.apache.commons.commons-io;version='[2.16.1,2.19.0)',\
 	org.apache.commons.logging;version='[1.2.0,1.3.0)',\


### PR DESCRIPTION
## Summary

The embedded ActiveMQ broker was failing to bind, which stalled GridAppsDBoot before it could complete startup.

GridOpticsServer declares a mandatory `@Reference` on a Realm service filtered by `(realm.type=system)`. Without the `pnnl.goss.core.security-system` bundle present in the OSGi runtime, that reference never resolves, so GridOpticsServer's component never activates, and the embedded ActiveMQ broker it owns never binds to its ports.

## Fix

Adds `pnnl.goss.core.security-system` to the three manifests that govern the bundle set:

- `gov.pnnl.goss.gridappsd/bnd.bnd`: `-buildpath`
- `gov.pnnl.goss.gridappsd/include.bndrun`: `shared.runrequires`
- `gov.pnnl.goss.gridappsd/run.bnd.bndrun`: `-runbundles`

With the bundle present, the Realm reference resolves, GridOpticsServer activates, and the broker binds.

## Verification

- `make clean` and `./gradlew dist` build cleanly and collect `pnnl.goss.core.security-system` into the launcher's bundle set.
- The ActiveMQ broker binds on 61616 (OpenWire), 61613 (STOMP), and 61614 (STOMP+SSL).
- GridAppsDBoot reaches the completed state instead of stalling.
- Blazegraph integration tests: 8/8 passing.
- Simulation-python integration tests: 5/5 passing.

## Test plan

- [x] Clean build via `make clean && ./gradlew dist`
- [x] Confirmed `pnnl.goss.core.security-system` present in the built launcher bundle directory
- [x] Broker port binding verified (61616/61613/61614)
- [x] GridAppsDBoot startup reaches completed state
- [x] Blazegraph integration suite (8/8)
- [x] Simulation-python integration suite (5/5)