### PR TITLE
ci: restore integration-test log visibility

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -54,7 +54,7 @@ jobs:
         r = g.get_response('goss.gridappsd.process.request.status.platform', '{}', timeout=5)
         g.disconnect()
         assert r is not None
-        " 2>/dev/null; then
+        "; then
             echo "Platform is ready after ${i} attempts"
             exit 0
           fi
@@ -62,7 +62,7 @@ jobs:
           sleep 10
         done
         echo "Platform did not become ready in time"
-        docker logs gridappsd --tail 50
+        docker logs gridappsd
         exit 1
       timeout-minutes: 6
 
@@ -79,7 +79,7 @@ jobs:
 
     - name: Show container logs on failure
       if: failure()
-      run: docker logs gridappsd --tail 100
+      run: docker logs gridappsd
 
     - name: Stop containers
       if: always()


### PR DESCRIPTION
## Summary

The integration-tests workflow has been silently discarding the real cause
of intermittent CI failures on develop. This PR is a diagnostic-visibility
change only; it does not alter test logic, timeouts, or stack bring up.

Two suppressions were hiding the actual failure:

- The platform-readiness probe pipes the Python STOMP client's stderr to
  /dev/null on every one of its 30 retry attempts, discarding the actual
  connection error the client raises when it cannot reach the broker.
- Both `docker logs gridappsd` calls used a `--tail` truncation (50 and
  100 lines), which can cut off the head of any startup trace on a
  container that has logged a lot by the time it fails.

## Changes

- Removed `2>/dev/null` from the readiness-probe Python client invocation
  so its stderr surfaces in the CI step log.
- Removed `--tail 50` from the readiness-timeout `docker logs gridappsd`
  call.
- Removed `--tail 100` from the on-failure `docker logs gridappsd` call.

No functional change: same commands, same timeouts, same retry loop,
same stack bring up.

## Test plan

- [x] YAML validated with a local parse.
- [ ] Confirm CI runs the workflow on this PR and captures the STOMP
      client error and/or full container log head on any failure.