### PR TITLE
security: pin requests>=2.32.4 and urllib3>=2.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ durable-rules
 gridappsd-python
 gridappsd-field-bus
 pytest
+requests>=2.32.4  # not a direct import here, pinned to clear GHSA-9hjg-9r4m-mvj7, GHSA-9wx4-h78v-vm56, and GHSA-gc5v-m9x4-r6x2
+urllib3>=2.5.0  # not a direct import here, pinned to clear GHSA-pq67-6m6q-mj2v and later urllib3 advisories


### PR DESCRIPTION
Adds explicit constraint pins for requests (>=2.32.4) and urllib3 (>=2.5.0) in requirements.txt to clear known CVEs. These are transitive dependencies (pulled by gridappsd-python and gridappsd-field-bus, not imported directly in this repo), so the pins protect anyone doing pip install -r requirements.txt. Supersedes the stale conflicting Snyk PR #1844 (targeted master, cannot merge against current base). Verified: isolated install resolved urllib3 2.7.0 + requests 2.34.2 with a live HTTPS round-trip succeeding, no urllib3 1.x to 2.x breakage in the usage path. GHSAs cleared noted inline in requirements.txt.