### PR TITLE
docs: add security policy to develop

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in GOSS-GridAPPS-D,
+please report it privately through GitHub's private vulnerability reporting.
+
+Go to the **Security** tab of this repository and click **Report a vulnerability**.
+This opens a private advisory visible only to the maintainers, so details are
+not disclosed publicly before a fix is available.
+
+Please include enough information to reproduce the issue: affected version or
+commit, a description of the impact, and steps to trigger the behavior.
+
+## Response Expectations
+
+GOSS-GridAPPS-D is a research platform maintained on a best-effort basis.
+We do not offer a formal service level agreement or a guaranteed response
+window, and we do not maintain a fixed supported-version matrix. Maintainers
+will acknowledge and triage reports as capacity allows, and will coordinate
+disclosure of any confirmed issue with the reporter.
+
+## Scope
+
+Reports about this repository's source code and its published artifacts are in
+scope. For issues in a dependency, please report them to that project directly;
+we will address the dependency update here once an upstream fix is available.


### PR DESCRIPTION
Mirrors the SECURITY.md already on `master` (commit feaa5e52, merged via PR #1886) so the security policy is also present on the active integration branch.

No functional changes: one file added, content byte-identical to the `master` copy.