### PR TITLE
fix: guard FieldBusManager topology null path (GADP-005, issue #1881)

### DIFF
--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/distributed/FieldBusManagerImpl.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/distributed/FieldBusManagerImpl.java
@@ -158,7 +158,7 @@ public class FieldBusManagerImpl implements FieldBusManager {
             // the first config delivery with a valid field.model.mrid, and root is null
             // while the background TopologyRequestProcess is still fetching the response.
             // Both states are normal; return null until topology is fully built.
-            if (topology == null || topology.root == null) {
+            if (!isTopologyReady()) {
                 return null;
             }
 
@@ -194,8 +194,7 @@ public class FieldBusManagerImpl implements FieldBusManager {
                 // during the idle window before the background fetch populates it, and
                 // when the topology response never arrived. Not-initialized is the
                 // correct answer in both cases; do not dereference a null root.
-                if (topology != null && topology.root != null
-                        && topology.root.DistributionArea != null) {
+                if (isTopologyFullyInitialized()) {
                     obj.addProperty("initialized", true);
                 } else {
                     obj.addProperty("initialized", false);
@@ -210,7 +209,7 @@ public class FieldBusManagerImpl implements FieldBusManager {
 
             // Defensive guard (M-npe): nothing to publish until topology is fully built.
             // topology.root is null until the background fetch completes.
-            if (topology == null || topology.root == null) {
+            if (!isTopologyReady()) {
                 return null;
             }
 
@@ -231,7 +230,7 @@ public class FieldBusManagerImpl implements FieldBusManager {
 
             @Override
             public void onMessage(Serializable response) {
-                if (topology == null || topology.root == null) {
+                if (!isTopologyReady()) {
                     // Topology not yet initialized (or the topology response never
                     // arrived, GADP-005); simulation output cannot be routed. The
                     // fallback message-bus id below dereferences topology.root, so idle
@@ -368,6 +367,22 @@ public class FieldBusManagerImpl implements FieldBusManager {
         return value != null ? value.toString() : null;
     }
 
+    // True once the background TopologyRequestProcess has parsed a response into
+    // a non-null root. Callers that only need the root tree (get_context,
+    // start_publishing, publishDeviceOutput's onMessage) use this guard rather
+    // than repeating the topology/root null check at each call site.
+    private boolean isTopologyReady() {
+        return topology != null && topology.root != null;
+    }
+
+    // True once root AND its DistributionArea have both populated: the stricter
+    // guard used by is_initilized, which reports "initialized" only when the
+    // full tree that downstream callers expect to traverse is present, not just
+    // a root shell.
+    private boolean isTopologyFullyInitialized() {
+        return isTopologyReady() && topology.root.DistributionArea != null;
+    }
+
 }
 
 class TopologyRequest implements Serializable {
@@ -390,10 +405,9 @@ class TopologyRequestProcess extends Thread {
 
     static final String TOPOLOGY_REQUEST_TOPIC = "goss.gridappsd.request.data.cimtopology";
 
-    // Bounded retry: the topology background service is registered but may not yet
-    // answer on the request queue at startup (a boot-order race). Give it up to
-    // this
-    // many attempts, sleeping between them, before idling.
+    // Bounded retry: the topology background service is registered but may not
+    // yet answer on the request queue at startup (a boot-order race). Give it
+    // up to this many attempts, sleeping between them, before idling.
     static final int MAX_TOPOLOGY_ATTEMPTS = 6;
     static final long TOPOLOGY_RETRY_SLEEP_MS = 1000L;
 
@@ -427,17 +441,42 @@ class TopologyRequestProcess extends Thread {
                 this.getFieldMeasurementIds(fieldModelMrid);
             }
 
+        } catch (InterruptedException e) {
+            // Expected on legitimate teardown: applyConfig() calls topology.interrupt()
+            // when the field model mrid changes, which unblocks Thread.sleep here.
+            // Restore the interrupt flag so any caller further up the stack still
+            // observes it, and log at debug/info rather than treating it as an error.
+            Thread.currentThread().interrupt();
+            if (logManager != null) {
+                logManager.info(ProcessStatus.RUNNING, null,
+                        "TopologyRequestProcess interrupted for field model mrid "
+                                + sanitizeForLog(fieldModelMrid) + "; stopping.");
+            }
         } catch (Exception e) {
-            e.printStackTrace();
+            if (logManager != null) {
+                logManager.error(ProcessStatus.ERROR, null,
+                        "TopologyRequestProcess failed for field model mrid "
+                                + sanitizeForLog(fieldModelMrid) + ": " + e.getMessage());
+            } else {
+                e.printStackTrace();
+            }
         }
 
     }
 
+    // Strip CR/LF from a value before it is interpolated into a log message
+    // (CWE-117 log injection). fieldModelMrid originates from ConfigAdmin config
+    // and is not otherwise validated, so sanitize at the point of logging rather
+    // than trusting the source.
+    private static String sanitizeForLog(String value) {
+        return value == null ? null : value.replace("\r", "").replace("\n", "");
+    }
+
     // Real bounded retry: request the topology, and while the response is null and
     // attempts remain, sleep BEFORE re-requesting so the background topology
-    // service
-    // has time to become ready. Replaces the earlier single-shot "if" that slept
-    // after its lone retry and so never actually waited for initialization.
+    // service has time to become ready. Replaces the earlier single-shot "if"
+    // that slept after its lone retry and so never actually waited for
+    // initialization.
     Serializable requestTopologyWithRetry(TopologyRequest request) throws Exception {
         Serializable topoResponse = client.getResponse(request.toString(), TOPOLOGY_REQUEST_TOPIC,
                 RESPONSE_FORMAT.JSON);
@@ -462,7 +501,8 @@ class TopologyRequestProcess extends Thread {
             // config or topology event; do not crash the bundle (GADP-001 posture).
             if (logManager != null) {
                 logManager.warn(ProcessStatus.RUNNING, null,
-                        "Topology service returned no response for field model mrid " + fieldModelMrid
+                        "Topology service returned no response for field model mrid "
+                                + sanitizeForLog(fieldModelMrid)
                                 + " after " + MAX_TOPOLOGY_ATTEMPTS
                                 + " attempts; FieldBusManager subscribed but idle. "
                                 + "Check that gridappsd-topology-background-service is answering "
@@ -486,7 +526,21 @@ class TopologyRequestProcess extends Thread {
         // Idle guard (GADP-005): run() only calls this after root is populated, but
         // guard defensively so a null or partial root leaves the measurement maps
         // empty rather than dereferencing null.
-        if (root == null || root.DistributionArea == null || root.DistributionArea.Substations == null) {
+        if (root == null) {
+            return;
+        }
+        if (root.DistributionArea == null || root.DistributionArea.Substations == null) {
+            // Distinct from the never-arrived case above: the topology response
+            // parsed into a non-null root, but the expected DistributionArea /
+            // Substations shape is missing. Warn so this malformed-but-non-null
+            // condition is visible rather than silently leaving the measurement
+            // maps empty.
+            if (logManager != null) {
+                logManager.warn(ProcessStatus.RUNNING, null,
+                        "Topology response for field model mrid " + sanitizeForLog(fieldModelMrid)
+                                + " parsed but did not contain the expected DistributionArea/Substations "
+                                + "shape; field measurement ids not populated.");
+            }
             return;
         }
 

--- a/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/distributed/FieldBusManagerImpl.java
+++ b/gov.pnnl.goss.gridappsd/src/gov/pnnl/goss/gridappsd/distributed/FieldBusManagerImpl.java
@@ -190,7 +190,12 @@ public class FieldBusManagerImpl implements FieldBusManager {
             JsonObject obj = new JsonObject();
 
             try {
-                if (topology != null && topology.root.DistributionArea != null) {
+                // Explicit null-guard on root (M-npe / GADP-005): topology.root is null
+                // during the idle window before the background fetch populates it, and
+                // when the topology response never arrived. Not-initialized is the
+                // correct answer in both cases; do not dereference a null root.
+                if (topology != null && topology.root != null
+                        && topology.root.DistributionArea != null) {
                     obj.addProperty("initialized", true);
                 } else {
                     obj.addProperty("initialized", false);
@@ -226,8 +231,11 @@ public class FieldBusManagerImpl implements FieldBusManager {
 
             @Override
             public void onMessage(Serializable response) {
-                if (topology == null) {
-                    // Topology not yet initialized; simulation output cannot be routed.
+                if (topology == null || topology.root == null) {
+                    // Topology not yet initialized (or the topology response never
+                    // arrived, GADP-005); simulation output cannot be routed. The
+                    // fallback message-bus id below dereferences topology.root, so idle
+                    // here rather than NPE.
                     return;
                 }
 
@@ -333,7 +341,7 @@ public class FieldBusManagerImpl implements FieldBusManager {
 
     private void launchTopology(String mrid) {
         fieldModelId = mrid;
-        topology = new TopologyRequestProcess(mrid, client);
+        topology = new TopologyRequestProcess(mrid, client, logManager);
         topology.start();
     }
 
@@ -380,64 +388,44 @@ class TopologyRequest implements Serializable {
 
 class TopologyRequestProcess extends Thread {
 
+    static final String TOPOLOGY_REQUEST_TOPIC = "goss.gridappsd.request.data.cimtopology";
+
+    // Bounded retry: the topology background service is registered but may not yet
+    // answer on the request queue at startup (a boot-order race). Give it up to
+    // this
+    // many attempts, sleeping between them, before idling.
+    static final int MAX_TOPOLOGY_ATTEMPTS = 6;
+    static final long TOPOLOGY_RETRY_SLEEP_MS = 1000L;
+
     String fieldModelMrid;
     Client client;
+    LogManager logManager;
     Root root = null;
     Map<String, ArrayList<FieldObject>> messageBus_measIds_map = new HashMap<String, ArrayList<FieldObject>>();
     Map<String, String> measId_messageBus_map = new HashMap<String, String>();
 
-    public TopologyRequestProcess(String fieldModelMrid, Client client) {
+    public TopologyRequestProcess(String fieldModelMrid, Client client, LogManager logManager) {
         this.fieldModelMrid = fieldModelMrid;
         this.client = client;
+        this.logManager = logManager;
     }
 
     @Override
     public void run() {
         try {
 
-            String topologyRequestTopic = "goss.gridappsd.request.data.cimtopology";
-            Gson gson = new Gson();
             TopologyRequest request = new TopologyRequest();
             request.mRID = fieldModelMrid;
 
-            Serializable topoResponse = client.getResponse(request.toString(), topologyRequestTopic,
-                    RESPONSE_FORMAT.JSON);
-            int attempt = 1;
-            if (topoResponse == null && attempt < 6) {
-                // May have to wait for Topology processor to initialize
-                topoResponse = client.getResponse(request.toString(), topologyRequestTopic,
-                        RESPONSE_FORMAT.JSON);
-                Thread.sleep(1000);
-                attempt++;
+            Serializable topoResponse = requestTopologyWithRetry(request);
+
+            // Null-idle fail-safe (GADP-005): when the topology service never answers,
+            // handleTopologyResponse leaves root null and logs an actionable warning
+            // rather than dereferencing null. Parse and downstream measurement lookup
+            // run only when the response actually populated root.
+            if (handleTopologyResponse(topoResponse)) {
+                this.getFieldMeasurementIds(fieldModelMrid);
             }
-            if (topoResponse != null && (topoResponse instanceof DataResponse)) {
-                String str = ((DataResponse) topoResponse).getData().toString();
-                root = gson.fromJson(str, Root.class);
-            } else {
-                root = gson.fromJson(topoResponse.toString(), Root.class);
-            }
-
-            /*
-             * feederList = root.feeders; if(root == null || feederList == null ||
-             * feederList.size() == 0){ throw new
-             * Exception("No Feeder available to create field message bus"); }
-             */
-
-            // NormalEnergizedFeeder feeder =
-            // root.DistributionArea.Substations.get(0).NormalEnergizedFeeder.get(0);
-
-            /*
-             * feeder.message_bus_id = feeder.id;
-             *
-             * int switch_area_index = 0; for (SwitchArea switchArea :
-             * feeder.FeederArea.SwitchAreas) { switchArea.message_bus_id = feeder.id + "."
-             * + switch_area_index; int secondary_area_index = 0; for (SecondaryArea
-             * secondaryArea : switchArea.SecondaryAreas) { secondaryArea.message_bus_id =
-             * feeder.id + "." + switch_area_index + "." + secondary_area_index;
-             * secondary_area_index++; } switch_area_index++; }
-             */
-
-            this.getFieldMeasurementIds(fieldModelMrid);
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -445,7 +433,62 @@ class TopologyRequestProcess extends Thread {
 
     }
 
+    // Real bounded retry: request the topology, and while the response is null and
+    // attempts remain, sleep BEFORE re-requesting so the background topology
+    // service
+    // has time to become ready. Replaces the earlier single-shot "if" that slept
+    // after its lone retry and so never actually waited for initialization.
+    Serializable requestTopologyWithRetry(TopologyRequest request) throws Exception {
+        Serializable topoResponse = client.getResponse(request.toString(), TOPOLOGY_REQUEST_TOPIC,
+                RESPONSE_FORMAT.JSON);
+        int attempt = 1;
+        while (topoResponse == null && attempt < MAX_TOPOLOGY_ATTEMPTS) {
+            Thread.sleep(TOPOLOGY_RETRY_SLEEP_MS);
+            topoResponse = client.getResponse(request.toString(), TOPOLOGY_REQUEST_TOPIC,
+                    RESPONSE_FORMAT.JSON);
+            attempt++;
+        }
+        return topoResponse;
+    }
+
+    // Parse the topology response into root. Returns true when root was populated,
+    // false when the response was null (idle fail-safe: root stays null, a warning
+    // is logged, and the caller must NOT proceed to parse or measurement lookup).
+    // Extracted from run() so the null and valid-parse paths are unit-testable
+    // without the live STOMP client.getResponse() call.
+    boolean handleTopologyResponse(Serializable topoResponse) {
+        if (topoResponse == null) {
+            // Subscribed-but-idle: no topology available. Recoverable on a later
+            // config or topology event; do not crash the bundle (GADP-001 posture).
+            if (logManager != null) {
+                logManager.warn(ProcessStatus.RUNNING, null,
+                        "Topology service returned no response for field model mrid " + fieldModelMrid
+                                + " after " + MAX_TOPOLOGY_ATTEMPTS
+                                + " attempts; FieldBusManager subscribed but idle. "
+                                + "Check that gridappsd-topology-background-service is answering "
+                                + TOPOLOGY_REQUEST_TOPIC + ".");
+            }
+            return false;
+        }
+
+        Gson gson = new Gson();
+        if (topoResponse instanceof DataResponse) {
+            String str = ((DataResponse) topoResponse).getData().toString();
+            root = gson.fromJson(str, Root.class);
+        } else {
+            root = gson.fromJson(topoResponse.toString(), Root.class);
+        }
+        return root != null;
+    }
+
     public void getFieldMeasurementIds(String fieldModelMrid) {
+
+        // Idle guard (GADP-005): run() only calls this after root is populated, but
+        // guard defensively so a null or partial root leaves the measurement maps
+        // empty rather than dereferencing null.
+        if (root == null || root.DistributionArea == null || root.DistributionArea.Substations == null) {
+            return;
+        }
 
         try {
             for (Substation substation : root.DistributionArea.Substations) {

--- a/gov.pnnl.goss.gridappsd/test/gov/pnnl/goss/gridappsd/distributed/TopologyRequestProcessTest.java
+++ b/gov.pnnl.goss.gridappsd/test/gov/pnnl/goss/gridappsd/distributed/TopologyRequestProcessTest.java
@@ -13,6 +13,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.Serializable;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -23,6 +25,7 @@ import gov.pnnl.goss.gridappsd.api.LogManager;
 import gov.pnnl.goss.gridappsd.dto.LogMessage.ProcessStatus;
 import pnnl.goss.core.Client;
 import pnnl.goss.core.DataResponse;
+import pnnl.goss.core.Request.RESPONSE_FORMAT;
 
 /**
  * Unit tests for TopologyRequestProcess response handling (GADP-005).
@@ -89,5 +92,94 @@ public class TopologyRequestProcessTest {
         org.junit.Assert.assertEquals("da-1", process.root.DistributionArea.id);
         // No warning is logged on the success path.
         Mockito.verify(logManager, Mockito.never()).warn(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    // --- Non-DataResponse valid-parse path: a raw JSON String response (not
+    // wrapped in DataResponse) must still parse into Root via toString(). ---
+
+    @Test
+    public void nonDataResponseStringParsesRootTree() throws Exception {
+        String topologyJson = "{\"DistributionArea\":{\"@id\":\"da-raw-1\",\"@type\":\"area\","
+                + "\"Substations\":[]}}";
+
+        TopologyRequestProcess process = new TopologyRequestProcess("mrid-raw-test", client, logManager);
+
+        boolean populated = process.handleTopologyResponse(topologyJson);
+
+        assertTrue("handleTopologyResponse must report root populated on a raw JSON String",
+                populated);
+        assertNotNull("root must be parsed from a non-DataResponse String", process.root);
+        assertNotNull("parsed root must carry its DistributionArea", process.root.DistributionArea);
+        org.junit.Assert.assertEquals("da-raw-1", process.root.DistributionArea.id);
+        // No warning is logged on the success path.
+        Mockito.verify(logManager, Mockito.never()).warn(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    // --- Bounded retry: requestTopologyWithRetry (GADP-005 fix round 2) ---
+
+    @Test
+    public void retrySucceedsImmediatelyWithoutSleepingOrRetrying() throws Exception {
+        DataResponse dataResponse = Mockito.mock(DataResponse.class);
+        Mockito.when(client.getResponse(Mockito.any(), Mockito.eq(TopologyRequestProcess.TOPOLOGY_REQUEST_TOPIC),
+                Mockito.eq(RESPONSE_FORMAT.JSON))).thenReturn(dataResponse);
+
+        TopologyRequestProcess process = new TopologyRequestProcess("mrid-immediate-success", client, logManager);
+        TopologyRequest request = new TopologyRequest();
+        request.mRID = "mrid-immediate-success";
+
+        Serializable result = process.requestTopologyWithRetry(request);
+
+        assertNotNull("first successful getResponse must be returned as-is", result);
+        org.junit.Assert.assertSame(dataResponse, result);
+        Mockito.verify(client, Mockito.times(1)).getResponse(Mockito.any(),
+                Mockito.eq(TopologyRequestProcess.TOPOLOGY_REQUEST_TOPIC), Mockito.eq(RESPONSE_FORMAT.JSON));
+    }
+
+    @Test
+    public void retryRecoversAfterTransientNullResponses() throws Exception {
+        DataResponse dataResponse = Mockito.mock(DataResponse.class);
+        // First two calls return null (service not yet answering); the third call
+        // succeeds. requestTopologyWithRetry must sleep between attempts and keep
+        // re-requesting rather than giving up on the first null.
+        Mockito.when(client.getResponse(Mockito.any(), Mockito.eq(TopologyRequestProcess.TOPOLOGY_REQUEST_TOPIC),
+                Mockito.eq(RESPONSE_FORMAT.JSON))).thenReturn(null, null, dataResponse);
+
+        TopologyRequestProcess process = new TopologyRequestProcess("mrid-recovers", client, logManager);
+        TopologyRequest request = new TopologyRequest();
+        request.mRID = "mrid-recovers";
+
+        Serializable result = process.requestTopologyWithRetry(request);
+
+        assertNotNull("requestTopologyWithRetry must return the eventual non-null response", result);
+        org.junit.Assert.assertSame(dataResponse, result);
+        // Exactly 3 calls: the initial request plus 2 retries, no more (no
+        // busy-spin past the successful attempt).
+        Mockito.verify(client, Mockito.times(3)).getResponse(Mockito.any(),
+                Mockito.eq(TopologyRequestProcess.TOPOLOGY_REQUEST_TOPIC), Mockito.eq(RESPONSE_FORMAT.JSON));
+    }
+
+    @Test
+    public void retryExhaustsAttemptsAndReturnsNullWhenServiceNeverAnswers() throws Exception {
+        Mockito.when(client.getResponse(Mockito.any(), Mockito.eq(TopologyRequestProcess.TOPOLOGY_REQUEST_TOPIC),
+                Mockito.eq(RESPONSE_FORMAT.JSON))).thenReturn(null);
+
+        TopologyRequestProcess process = new TopologyRequestProcess("mrid-exhausted", client, logManager);
+        TopologyRequest request = new TopologyRequest();
+        request.mRID = "mrid-exhausted";
+
+        Serializable result = process.requestTopologyWithRetry(request);
+
+        assertNull("requestTopologyWithRetry must return null once attempts are exhausted", result);
+        // Exactly MAX_TOPOLOGY_ATTEMPTS calls: the initial request plus
+        // (MAX_TOPOLOGY_ATTEMPTS - 1) retries, no more.
+        Mockito.verify(client, Mockito.times(TopologyRequestProcess.MAX_TOPOLOGY_ATTEMPTS)).getResponse(
+                Mockito.any(), Mockito.eq(TopologyRequestProcess.TOPOLOGY_REQUEST_TOPIC),
+                Mockito.eq(RESPONSE_FORMAT.JSON));
+
+        // Feeding the exhausted (null) result into handleTopologyResponse exercises
+        // the full null-idle path this retry loop feeds into.
+        boolean populated = process.handleTopologyResponse(result);
+        assertFalse("null result after exhausted retries must leave root unpopulated", populated);
+        assertNull("root must remain null after exhausted retries", process.root);
     }
 }

--- a/gov.pnnl.goss.gridappsd/test/gov/pnnl/goss/gridappsd/distributed/TopologyRequestProcessTest.java
+++ b/gov.pnnl.goss.gridappsd/test/gov/pnnl/goss/gridappsd/distributed/TopologyRequestProcessTest.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2017, Battelle Memorial Institute All rights reserved.
+ * Battelle Memorial Institute (hereinafter Battelle) hereby grants permission
+ * to any person or entity lawfully obtaining a copy of this software and
+ * associated documentation files (hereinafter the Software) to redistribute
+ * and use the Software in source and binary forms, with or without
+ * modification.
+ ******************************************************************************/
+package gov.pnnl.goss.gridappsd.distributed;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import gov.pnnl.goss.gridappsd.api.LogManager;
+import gov.pnnl.goss.gridappsd.dto.LogMessage.ProcessStatus;
+import pnnl.goss.core.Client;
+import pnnl.goss.core.DataResponse;
+
+/**
+ * Unit tests for TopologyRequestProcess response handling (GADP-005).
+ *
+ * These assert the null-idle fail-safe and the valid-parse path per the
+ * acceptance criteria: 1. A null topology response does not throw, leaves root
+ * null, and logs an actionable warning (subscribed-but-idle posture,
+ * recoverable later). 2. A valid DataResponse carrying topology JSON parses
+ * into a Root tree.
+ *
+ * The response-handling logic is extracted into the package-visible
+ * handleTopologyResponse so it can be exercised without the live STOMP
+ * client.getResponse() call that run() otherwise makes.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class TopologyRequestProcessTest {
+
+    @Mock
+    private Client client;
+
+    @Mock
+    private LogManager logManager;
+
+    // --- Null-idle fail-safe: null response must not NPE; root stays null ---
+
+    @Test
+    public void nullResponseLeavesRootNullAndDoesNotThrow() {
+        TopologyRequestProcess process = new TopologyRequestProcess("mrid-null-test", client, logManager);
+
+        boolean populated = process.handleTopologyResponse(null);
+
+        assertFalse("handleTopologyResponse must report root not populated on null", populated);
+        assertNull("root must remain null when the topology response is null", process.root);
+    }
+
+    @Test
+    public void nullResponseLogsActionableWarning() {
+        TopologyRequestProcess process = new TopologyRequestProcess("mrid-warn-test", client, logManager);
+
+        process.handleTopologyResponse(null);
+
+        // The warning must name the idle posture so operators can act on it. The
+        // mrid is included so the message identifies which field model is idle.
+        Mockito.verify(logManager).warn(Mockito.eq(ProcessStatus.RUNNING), Mockito.isNull(),
+                Mockito.contains("mrid-warn-test"));
+    }
+
+    // --- Valid-parse path: a DataResponse carrying topology JSON parses Root ---
+
+    @Test
+    public void validDataResponseParsesRootTree() {
+        String topologyJson = "{\"DistributionArea\":{\"@id\":\"da-1\",\"@type\":\"area\","
+                + "\"Substations\":[]}}";
+        DataResponse dataResponse = Mockito.mock(DataResponse.class);
+        Mockito.when(dataResponse.getData()).thenReturn(topologyJson);
+
+        TopologyRequestProcess process = new TopologyRequestProcess("mrid-parse-test", client, logManager);
+
+        boolean populated = process.handleTopologyResponse(dataResponse);
+
+        assertTrue("handleTopologyResponse must report root populated on valid JSON", populated);
+        assertNotNull("root must be parsed from a valid DataResponse", process.root);
+        assertNotNull("parsed root must carry its DistributionArea", process.root.DistributionArea);
+        org.junit.Assert.assertEquals("da-1", process.root.DistributionArea.id);
+        // No warning is logged on the success path.
+        Mockito.verify(logManager, Mockito.never()).warn(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+}


### PR DESCRIPTION
## What
Fixes the NullPointerException in `TopologyRequestProcess.run` (issue #1881): `Cannot invoke "java.io.Serializable.toString()" because "topoResponse" is null`.

The else branch called `topoResponse.toString()` on a possibly-null topology response, and the retry that was meant to wait for the topology processor never actually waited (single-shot if, slept after the lone retry).

## Fix (SITE A: FieldBusManagerImpl.TopologyRequestProcess)
- Bounded while-retry that sleeps BEFORE re-requesting (gives the topology processor time to become ready), capped at MAX_TOPOLOGY_ATTEMPTS.
- Null-idle fail-safe: on a still-null response, log an actionable warning and leave root null rather than dereferencing. Parse only in the confirmed non-null branch.
- Downstream `topology.root` derefs guarded via isTopologyReady()/isTopologyFullyInitialized() helpers (subscribed-but-idle posture, matching GADP-001).
- InterruptedException handled with re-interrupt; other exceptions logged via logManager; CR/LF sanitized on logged mrid.

## Tests
New TopologyRequestProcessTest: bounded-retry call counts (immediate success, null-then-recover, exhausted-retries to idle), null-idle, valid-parse, and non-DataResponse JSON path. 7/7 green. Full module suite: 266 tests, 2 pre-existing DTOComponentTests failures unrelated to this change (verified on clean develop).

## Scope
SITE A only (the reported TopologyRequestProcess.run trace). A sibling NPE at ProcessEvent.java:424 (get_context/handleRequest path) is tracked separately and NOT in this PR. applyConfig is untouched.

## Note
This stops the crash (idle-instead-of-NPE); it does not make topology arrive: that depends on the cimgraph/Blazegraph chain (topology service delivering areas). Reviewed by the workspace team (Dutch APPROVE, Leon/Tess/Wren findings addressed).