### PR TITLE
bridge interval fix for realtime simulation

### DIFF
--- a/services/helicsgossbridge/service/helics_goss_bridge.py
+++ b/services/helicsgossbridge/service/helics_goss_bridge.py
@@ -294,7 +294,10 @@ class HelicsGossBridge(object):
         self.simulation_start = int(self._simulation_request.get("simulation_config", {}).get("start_time", 0))
         self.pause_after_measurements = \
             self._simulation_request.get("simulation_config", {}).get("pause_after_measurements", False)
-        self.simulation_interval = int(self._simulation_request.get("simulation_config", {}).get("interval", 1))
+        if self.run_realtime:
+            self.simulation_interval = 1
+        else:
+            self.simulation_interval = int(self._simulation_request.get("simulation_config", {}).get("interval", 1))
         self._generate_cimgraph_models()
         # build GLD property names to CIM mrid map
         self._create_cim_object_map()


### PR DESCRIPTION
The bridge was assuming the interval would be 1 when getting a realtime simulation request. This fix forces the bridge to use an interval of 1 when running a realtime simulation.
