### PR TITLE
Restore log message

### DIFF
--- a/services/helicsgossbridge/service/helics_goss_bridge.py
+++ b/services/helicsgossbridge/service/helics_goss_bridge.py
@@ -644,8 +644,8 @@ class HelicsGossBridge(object):
             self._gad_connection.send_simulation_status('COMPLETE',
                                                         logMsg,
                                                         'INFO')
-            self._gat_connection.send_simulation_status('COMPLETE',
-                                                        f"Simulation {self._simulation_id} compete",
+            self._gad_connection.send_simulation_status('COMPLETE',
+                                                        f"Simulation {self._simulation_id} complete",
                                                         'INFO')
         except Exception as e:
             message_str = f'Error in run simulation {traceback.format_exc()}'

--- a/services/helicsgossbridge/service/helics_goss_bridge.py
+++ b/services/helicsgossbridge/service/helics_goss_bridge.py
@@ -644,6 +644,9 @@ class HelicsGossBridge(object):
             self._gad_connection.send_simulation_status('COMPLETE',
                                                         logMsg,
                                                         'INFO')
+            self._gat_connection.send_simulation_status('COMPLETE',
+                                                        f"Simulation {self._simulation_id} compete",
+                                                        'INFO')
         except Exception as e:
             message_str = f'Error in run simulation {traceback.format_exc()}'
             log.error(message_str)


### PR DESCRIPTION
I was unaware that a particular log message in the bridge is used by gridappsd-python Simulation class for an 'on simulation complete' functionality. I removed this message breaking that functionality. I've added back to the bridge to retain this functionality.
